### PR TITLE
Prepare to use SVG icons in style

### DIFF
--- a/src/komap.py
+++ b/src/komap.py
@@ -526,11 +526,11 @@ if options.renderer == "mapnik":
                                                     os.makedirs(icons_path + "komap/")
                                                 if not os.path.exists(icons_path + "komap/" + fname):
                                                     im.save(icons_path + "komap/" + fname, "PNG")
-                                                xml += xml_linepatternsymbolizer("komap/" + fname)
+                                                xml += xml_linepatternsymbolizer("komap/" + fname, entry["style"].get("spacing","0"), entry["style"].get("max-error","0.25"), entry["style"].get("allow-overlap","false"))
                                             except:
                                                 print >> sys.stderr, "Error writing to ", icons_path + "komap/" + fname
                                         else:
-                                            xml += xml_linepatternsymbolizer(entry["style"]["pattern-image"])
+                                            xml += xml_linepatternsymbolizer(entry["style"]["pattern-image"], entry["style"].get("spacing","0"), entry["style"].get("max-error","0.25"), entry["style"].get("allow-overlap","false"))
                                 sql.add(entry["sql"])
                                 itags.update(entry["chooser"].get_interesting_tags(entry["type"], zoom))
                                 xml += xml_rule_end()

--- a/src/komap.py
+++ b/src/komap.py
@@ -526,11 +526,14 @@ if options.renderer == "mapnik":
                                                     os.makedirs(icons_path + "komap/")
                                                 if not os.path.exists(icons_path + "komap/" + fname):
                                                     im.save(icons_path + "komap/" + fname, "PNG")
-                                                xml += xml_linepatternsymbolizer("komap/" + fname, entry["style"].get("spacing","0"), entry["style"].get("max-error","0.25"), entry["style"].get("allow-overlap","false"))
+                                                xml += xml_linepatternsymbolizer("komap/" + fname)
                                             except:
                                                 print >> sys.stderr, "Error writing to ", icons_path + "komap/" + fname
                                         else:
-                                            xml += xml_linepatternsymbolizer(entry["style"]["pattern-image"], entry["style"].get("spacing","0"), entry["style"].get("max-error","0.25"), entry["style"].get("allow-overlap","false"))
+                                            if entry["style"].get("-x-kot-render", "none") == "svg":
+                                                xml += xml_linemarkerssymbolizer(entry["style"]["pattern-image"], entry["style"].get("spacing","100"), entry["style"].get("allow-overlap","false"))
+                                            else:
+                                                xml += xml_linepatternsymbolizer(entry["style"]["pattern-image"])
                                 sql.add(entry["sql"])
                                 itags.update(entry["chooser"].get_interesting_tags(entry["type"], zoom))
                                 xml += xml_rule_end()

--- a/src/libkomapnik.py
+++ b/src/libkomapnik.py
@@ -88,7 +88,7 @@ def xml_pointsymbolizer(path="", width="", height="", opacity=1, overlap="false"
     if height:
         height = ' height="%s" ' % height
     return """
-    <PointSymbolizer file="%s" %s %s opacity="%s" allow-overlap="%s" />"""\
+    <MarkersSymbolizer file="%s" %s %s opacity="%s" allow-overlap="%s" />"""\
             % (os.path.join(icons_path, path), width, height, opacity, overlap)
 
 

--- a/src/libkomapnik.py
+++ b/src/libkomapnik.py
@@ -129,10 +129,14 @@ def xml_polygonpatternsymbolizer(file=""):
     <PolygonPatternSymbolizer file="%s"/>""" % (os.path.join(icons_path, file))
 
 
-def xml_linepatternsymbolizer(file="", spacing="0", max_error="0.25", allow_overlap="false"):
-
+def xml_linepatternsymbolizer(file=""):
     return """
-    <MarkersSymbolizer file="%s" spacing="%s" max-error="%s" allow-overlap="%s" placement="line"/>""" % (os.path.join(icons_path, file), spacing, float(max_error), allow_overlap)
+    <LinePatternSymbolizer file="%s" />""" % (os.path.join(icons_path, file))
+
+
+def xml_linemarkerssymbolizer(file="", spacing="100", allow_overlap="false"):
+    return """
+    <MarkersSymbolizer file="%s" spacing="%s" allow-overlap="%s" placement="line"/>""" % (os.path.join(icons_path, file), spacing, allow_overlap)
 
 
 def xml_textsymbolizer(

--- a/src/libkomapnik.py
+++ b/src/libkomapnik.py
@@ -88,7 +88,7 @@ def xml_pointsymbolizer(path="", width="", height="", opacity=1, overlap="false"
     if height:
         height = ' height="%s" ' % height
     return """
-    <MarkersSymbolizer file="%s" %s %s opacity="%s" allow-overlap="%s" />"""\
+    <MarkersSymbolizer file="%s" %s %s opacity="%s" allow-overlap="%s" placement="point" />"""\
             % (os.path.join(icons_path, path), width, height, opacity, overlap)
 
 
@@ -129,9 +129,10 @@ def xml_polygonpatternsymbolizer(file=""):
     <PolygonPatternSymbolizer file="%s"/>""" % (os.path.join(icons_path, file))
 
 
-def xml_linepatternsymbolizer(file=""):
+def xml_linepatternsymbolizer(file="", spacing="0", max_error="0.25", allow_overlap="false"):
+
     return """
-    <LinePatternSymbolizer file="%s"/>""" % (os.path.join(icons_path, file))
+    <MarkersSymbolizer file="%s" spacing="%s" max-error="%s" allow-overlap="%s" placement="line"/>""" % (os.path.join(icons_path, file), spacing, float(max_error), allow_overlap)
 
 
 def xml_textsymbolizer(

--- a/src/libkomapnik.py
+++ b/src/libkomapnik.py
@@ -136,7 +136,7 @@ def xml_linepatternsymbolizer(file=""):
 
 def xml_linemarkerssymbolizer(file="", spacing="100", allow_overlap="false"):
     return """
-    <MarkersSymbolizer file="%s" spacing="%s" allow-overlap="%s" placement="line"/>""" % (os.path.join(icons_path, file), spacing, allow_overlap)
+    <MarkersSymbolizer file="%s" spacing="%s" max-error="1" allow-overlap="%s" placement="line"/>""" % (os.path.join(icons_path, file), spacing, allow_overlap)
 
 
 def xml_textsymbolizer(

--- a/src/libkomapnik.py
+++ b/src/libkomapnik.py
@@ -136,7 +136,7 @@ def xml_linepatternsymbolizer(file=""):
 
 def xml_linemarkerssymbolizer(file="", spacing="100", allow_overlap="false"):
     return """
-    <MarkersSymbolizer file="%s" spacing="%s" max-error="1" allow-overlap="%s" placement="line"/>""" % (os.path.join(icons_path, file), spacing, allow_overlap)
+    <MarkersSymbolizer file="%s" spacing="%s" allow-overlap="%s" placement="line"/>""" % (os.path.join(icons_path, file), spacing, allow_overlap)
 
 
 def xml_textsymbolizer(


### PR DESCRIPTION
SVG icons for points use now MarkersSymbolizer without PointSymbolizer.
SVG line patterns use MarkersSymbolizer without LinePatternSymbolizer only if style have key «-x-kot-render: svg;»