### PR TITLE
Use integer primary key instead of dedicated index in temporary node database

### DIFF
--- a/src/osm2tiles.py
+++ b/src/osm2tiles.py
@@ -80,11 +80,13 @@ print sanitize(" ;=")
 def initDB(filename):
     conn = sqlite3.connect(filename)
     c = conn.cursor()
-    # create table
-    c.execute('''CREATE TABLE nodes (id integer, lat real, lon real)''')
-    # create index in the id column
-    # - this makes node id lookup MUCH faster
-    c.execute('''CREATE INDEX id_idx ON nodes(id)''')
+    # create table with the osm element integer id being the primary index
+    # - according to the sqlite documentation this will equal the index with the
+    #   built in rowid index, providing the same speedup as a separate index while
+    #   saving space - win-win ! :)
+    # - brief testing shows that this makes the osm -> tiles operation about 5% faster
+    #   but more importantly makes the temporary sqlite database 30% smaller! :)
+    c.execute('''CREATE TABLE nodes (id integer, lat real, lon real, PRIMARY KEY (id))''')
     return conn
 
 


### PR DESCRIPTION
This reduces size of the temporary sqlite node database and is also
slightly faster (5%) than the separate index.