### PR TITLE
Added option to configure labels fallback tags.

### DIFF
--- a/src/komap.py
+++ b/src/komap.py
@@ -60,7 +60,9 @@ parser.add_option("-f", "--minzoom", dest="minzoom", default=0, type="int",
 parser.add_option("-t", "--maxzoom", dest="maxzoom", default=19, type="int",
                   help="maximal available zoom level", metavar="ZOOM")
 parser.add_option("-l", "--locale", dest="locale",
-                  help="language that should be used for labels (ru, en, be, uk..)", metavar="LANG")
+                  help="language that should be used for labels (ru,en,be,uk,..)", metavar="LANG")
+parser.add_option("-F", "--label-fallback", dest="label_fallback",
+                  help="tags to use as additional fallback for labels (int_name,name,..)", default="name")
 parser.add_option("-o", "--output-file", dest="outfile", default="-",
                   help="output filename (defaults to stdout)", metavar="FILE")
 parser.add_option("-p", "--osm2pgsql-style", dest="osm2pgsqlstyle", default="-",

--- a/src/libkomb.py
+++ b/src/libkomb.py
@@ -437,17 +437,19 @@ def komap_mapbox(options, style):
                 )
 
                 locales = []
+                fallback = []
                 if options.locale is not None:
                     locales = options.locale.split(",")
+                if options.label_fallback is not None:
+                    fallback = options.label_fallback.split(",")
                 zoom_text = {}
                 for z, v in st.get("text").items():
                     if v.expr_text == "tag(\"name\")":
                         coalesce = ["coalesce"]
                         for l in locales:
                             coalesce.append(["get", "name:%s" % (l)])
-                        if "en" in locales:
-                            coalesce += [["get", "int_name"]]
-                        coalesce += [["get", "name"]]
+                        for f in fallback:
+                            coalesce.append(["get", f])
 
                         zoom_text[z] = coalesce
                     else:


### PR DESCRIPTION
Added `--label-fallback` (`-F`) komap.py option to be able to control fallbacks outside of a style generation script. This applies to `mapbox-style-language` renderer.

The change itself not really backwards compatible as `int_name, name` fallback was hardcoded for `en` language. While I've configured `name` fallback as default.