### PR TITLE
Update codebase for Python 3

### DIFF
--- a/src/backend/postgis/__init__.py
+++ b/src/backend/postgis/__init__.py
@@ -19,6 +19,7 @@
 from twms import projections
 import psycopg2
 import shapely.wkb
+from functools import reduce
 
 
 class Empty:
@@ -112,14 +113,14 @@ class PostGisBackend:
                 adp = " OR ".join(adp)
 
             req = "SELECT %s FROM %s WHERE (%s) and way && SetSRID('BOX3D(%s %s,%s %s)'::box3d,900913);" % (taghint, table, adp, bbox[0], bbox[1], bbox[2], bbox[3])
-            print req
+            print(req)
             b.execute(req)
             names = [q[0] for q in b.description]
 
             for row in b.fetchall():
 
-                row_dict = dict(map(None, names, row))
-                for k, v in row_dict.items():
+                row_dict = dict(zip(names, row))
+                for k, v in list(row_dict.items()):
                     if not v:
                         del row_dict[k]
                 geom = shapely.wkb.loads(row_dict["way"].decode('hex'))

--- a/src/backend/vtile/__init__.py
+++ b/src/backend/vtile/__init__.py
@@ -18,6 +18,7 @@
 
 from twms import projections
 import twms.bbox
+from functools import reduce
 
 
 class Empty:
@@ -74,8 +75,9 @@ class QuadTileBackend:
         self.keep_tiles = 15                # a number of tiles to cache in memory
         self.tile_load_log = []             # used when selecting which tile to unload
 
-    def filename(self, (z, x, y)):
+    def filename(self, tile):
 
+        (z, x, y) = tile
         return "%s/z%s/%s/x%s/%s/y%s.vtile" % (self.path, z, x / 1024, x, y / 1024, y)
 
     def load_tile(self, k):
@@ -83,7 +85,7 @@ class QuadTileBackend:
         try:
             f = open(self.filename(k))
         except IOError:
-            print ("Failed open: '%s'" % self.filename(k))
+            print(("Failed open: '%s'" % self.filename(k)))
             return {}
         t = {}
         for line in f:
@@ -105,7 +107,7 @@ class QuadTileBackend:
                     del self.tiles[tile]
                     self.tile_load_log.remove(tile)
                     # debug ("killed tile: %s" % (tile,))
-                except KeyError, ValueError:
+                except (KeyError, ValueError):
                     pass
                     # debug ("tile killed not by us: %s" % (tile,))
 

--- a/src/drules_struct_pb2.py
+++ b/src/drules_struct_pb2.py
@@ -117,7 +117,7 @@ _PATHSYMPROTO = descriptor.Descriptor(
         descriptor.FieldDescriptor(
             name='name', full_name='PathSymProto.name', index=0,
             number=1, type=9, cpp_type=9, label=2,
-            has_default_value=False, default_value=unicode("", "utf-8"),
+            has_default_value=False, default_value=str("", "utf-8"),
             message_type=None, enum_type=None, containing_type=None,
             is_extension=False, extension_scope=None,
             options=None),
@@ -334,7 +334,7 @@ _SYMBOLRULEPROTO = descriptor.Descriptor(
     descriptor.FieldDescriptor(
       name='name', full_name='SymbolRuleProto.name', index=0,
       number=1, type=9, cpp_type=9, label=2,
-      has_default_value=False, default_value=unicode("", "utf-8"),
+      has_default_value=False, default_value=str("", "utf-8"),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
@@ -635,7 +635,7 @@ _CLASSIFELEMENTPROTO = descriptor.Descriptor(
     descriptor.FieldDescriptor(
       name='name', full_name='ClassifElementProto.name', index=0,
       number=1, type=9, cpp_type=9, label=2,
-      has_default_value=False, default_value=unicode("", "utf-8"),
+      has_default_value=False, default_value=str("", "utf-8"),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
@@ -724,92 +724,79 @@ DESCRIPTOR.message_types_by_name['ClassifElementProto'] = _CLASSIFELEMENTPROTO
 DESCRIPTOR.message_types_by_name['ContainerProto'] = _CONTAINERPROTO
 
 
-class DashDotProto(message.Message):
-    __metaclass__ = reflection.GeneratedProtocolMessageType
+class DashDotProto(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
     DESCRIPTOR = _DASHDOTPROTO
 
     # @@protoc_insertion_point(class_scope:DashDotProto)
 
 
-class PathSymProto(message.Message):
-    __metaclass__ = reflection.GeneratedProtocolMessageType
+class PathSymProto(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
     DESCRIPTOR = _PATHSYMPROTO
 
     # @@protoc_insertion_point(class_scope:PathSymProto)
 
 
-class LineRuleProto(message.Message):
-    __metaclass__ = reflection.GeneratedProtocolMessageType
+class LineRuleProto(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
     DESCRIPTOR = _LINERULEPROTO
 
     # @@protoc_insertion_point(class_scope:LineRuleProto)
 
 
-class LineDefProto(message.Message):
-    __metaclass__ = reflection.GeneratedProtocolMessageType
+class LineDefProto(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
     DESCRIPTOR = _LINEDEFPROTO
 
     # @@protoc_insertion_point(class_scope:LineDefProto)
 
 
-class AreaRuleProto(message.Message):
-    __metaclass__ = reflection.GeneratedProtocolMessageType
+class AreaRuleProto(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
     DESCRIPTOR = _AREARULEPROTO
 
     # @@protoc_insertion_point(class_scope:AreaRuleProto)
 
 
-class SymbolRuleProto(message.Message):
-    __metaclass__ = reflection.GeneratedProtocolMessageType
+class SymbolRuleProto(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
     DESCRIPTOR = _SYMBOLRULEPROTO
 
     # @@protoc_insertion_point(class_scope:SymbolRuleProto)
 
 
-class CaptionDefProto(message.Message):
-    __metaclass__ = reflection.GeneratedProtocolMessageType
+class CaptionDefProto(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
     DESCRIPTOR = _CAPTIONDEFPROTO
 
     # @@protoc_insertion_point(class_scope:CaptionDefProto)
 
 
-class CaptionRuleProto(message.Message):
-    __metaclass__ = reflection.GeneratedProtocolMessageType
+class CaptionRuleProto(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
     DESCRIPTOR = _CAPTIONRULEPROTO
 
     # @@protoc_insertion_point(class_scope:CaptionRuleProto)
 
 
-class CircleRuleProto(message.Message):
-    __metaclass__ = reflection.GeneratedProtocolMessageType
+class CircleRuleProto(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
     DESCRIPTOR = _CIRCLERULEPROTO
 
     # @@protoc_insertion_point(class_scope:CircleRuleProto)
 
 
-class PathTextRuleProto(message.Message):
-    __metaclass__ = reflection.GeneratedProtocolMessageType
+class PathTextRuleProto(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
     DESCRIPTOR = _PATHTEXTRULEPROTO
 
     # @@protoc_insertion_point(class_scope:PathTextRuleProto)
 
 
-class DrawElementProto(message.Message):
-    __metaclass__ = reflection.GeneratedProtocolMessageType
+class DrawElementProto(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
     DESCRIPTOR = _DRAWELEMENTPROTO
 
     # @@protoc_insertion_point(class_scope:DrawElementProto)
 
 
-class ClassifElementProto(message.Message):
-    __metaclass__ = reflection.GeneratedProtocolMessageType
+class ClassifElementProto(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
     DESCRIPTOR = _CLASSIFELEMENTPROTO
 
     # @@protoc_insertion_point(class_scope:ClassifElementProto)
 
 
-class ContainerProto(message.Message):
-    __metaclass__ = reflection.GeneratedProtocolMessageType
+class ContainerProto(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
     DESCRIPTOR = _CONTAINERPROTO
 
     # @@protoc_insertion_point(class_scope:ContainerProto)

--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -16,13 +16,13 @@
 #   along with kothic.  If not, see <http://www.gnu.org/licenses/>.
 
 
-from debug import debug, Timer
-from backend.vtile import QuadTileBackend as DataBackend
+from .debug import debug, Timer
+from .backend.vtile import QuadTileBackend as DataBackend
 # from backend.postgis import PostGisBackend as DataBackend
 # from style import Styling
-from mapcss import MapCSS
+from .mapcss import MapCSS
 
-from render import RasterTile
+from .render import RasterTile
 
 svg = False
 

--- a/src/generate_map_key.py
+++ b/src/generate_map_key.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from mapcss import MapCSS
-import mapcss.webcolors
-whatever_to_hex = mapcss.webcolors.webcolors.whatever_to_hex
+from .mapcss import MapCSS
+from .mapcss import webcolors
+import importlib
+whatever_to_hex = webcolors.webcolors.whatever_to_hex
 
 import json
 
@@ -10,8 +11,9 @@ import cairo
 
 import sys
 
-reload(sys)
-sys.setdefaultencoding("utf-8")
+importlib.reload(sys)
+if hasattr(sys, "setdefaultencoding"):
+    sys.setdefaultencoding("utf-8")
 
 minzoom = 0
 maxzoom = 18
@@ -23,7 +25,7 @@ style.parse(open(sys.argv[1], "r").read(), clamp=False)
 
 
 tags = [json.loads(x) for x in open("data/tags.list", "r")]
-print len(tags)
+print(len(tags))
 # a = cairo.PDFSurface("legend.pdf",100,100*len(tags))
 
 maxzoom += 1
@@ -42,7 +44,7 @@ for tag in tags:
         styles = style.get_style_dict("area", tag, zoom, olddict=styles.copy())
         styles = style.get_style_dict("line", tag, zoom, olddict=styles.copy())
 
-        styles = styles.values()
+        styles = list(styles.values())
         styles.sort(key=lambda x: x.get('z-index', 0))
         if len(styles) > 0:
             for st in styles:
@@ -77,7 +79,7 @@ for tag in tags:
                     cr.stroke()
                 if "icon-image" in st:
                     icons[st["icon-image"]] = icons.get(st["icon-image"], set())
-                    icons[st["icon-image"]].add('[' + ']['.join([k + "=" + v for k, v in tag.iteritems()]) + ']')
+                    icons[st["icon-image"]].add('[' + ']['.join([k + "=" + v for k, v in tag.items()]) + ']')
 
             if had_lines:
                 cr.move_to(0 + sample_width * zoom, 25 + 50 * i)
@@ -85,7 +87,7 @@ for tag in tags:
                 cr.show_text('z' + str(zoom))
 
     if had_lines:
-        text = '[' + ']['.join([k + "=" + v for k, v in tag.iteritems()]) + ']'
+        text = '[' + ']['.join([k + "=" + v for k, v in tag.items()]) + ']'
         cr.move_to(10, 20 + 50 * i)
         cr.set_source_rgb(0, 0, 0)
         cr.show_text(text)
@@ -98,8 +100,8 @@ for tag in tags:
         i += 1
 # a.finish()\
 ss = open("icons.html", "w")
-print >> ss, "<html><body><table border=1>"
-for k, v in icons.iteritems():
-    print >> ss, "<tr><td><img src='%s' width='24' height='24'></td><td>%s</td><td>%s</td></tr>\n" % (k.lower(), k.lower(), "<br>".join(list(v)))
-print >> ss, "</table></body></html>"
+print("<html><body><table border=1>", file=ss)
+for k, v in icons.items():
+    print("<tr><td><img src='%s' width='24' height='24'></td><td>%s</td><td>%s</td></tr>\n" % (k.lower(), k.lower(), "<br>".join(list(v))), file=ss)
+print("</table></body></html>", file=ss)
 a.write_to_png("legend.png")

--- a/src/gtk-app.py
+++ b/src/gtk-app.py
@@ -22,14 +22,14 @@ import math
 import string
 import threading
 import time
-import Queue
+import queue
 import os
 
 
 # from backend.postgis import PostGisBackend as DataBackend
-from backend.vtile import QuadTileBackend as DataBackend
-from mapcss import MapCSS as Styling
-from gtk_widget import KothicWidget
+from .backend.vtile import QuadTileBackend as DataBackend
+from .mapcss import MapCSS as Styling
+from .gtk_widget import KothicWidget
 
 
 try:

--- a/src/gtk_widget.py
+++ b/src/gtk_widget.py
@@ -24,10 +24,10 @@ import string
 import threading
 import datetime
 import time
-import Queue
+import queue
 import os
-from render import RasterTile
-from debug import debug, Timer
+from .render import RasterTile
+from .debug import debug, Timer
 import twms.bbox
 from twms import projections
 
@@ -81,9 +81,9 @@ class KothicWidget(gtk.DrawingArea):
 
     def zoom_to(self, bbox):
         self.zoom = twms.bbox.zoom_for_bbox(bbox, (self.width, self.height), {"proj": "EPSG:3857", "max_zoom": self.max_zoom}) - 1
-        print "Zoom:", self.zoom
+        print("Zoom:", self.zoom)
         self.center_coord = ((bbox[0] + bbox[2]) / 2, (bbox[1] + bbox[3]) / 2)
-        print self.center_coord
+        print(self.center_coord)
         self.redraw()
 
     def motion_ev(self, widget, event):
@@ -120,7 +120,7 @@ class KothicWidget(gtk.DrawingArea):
             x = event.x
             y = event.y
             lo1, la1, lo2, la2 = projections.from4326(self.bbox, "EPSG:3857")
-            print lo1, la1, lo2, la2
+            print(lo1, la1, lo2, la2)
             # self.center_coord = projections.to4326((0.5*(self.width+self.dx)/self.width*(lo1-lo2)+lo2, la1+(0.5*(self.height+self.dy)/self.height*(la2-la1))),"EPSG:3857")
 
             self.center_coord = projections.to4326((0.5 * (self.width + 2 * self.dx) / self.width * (lo1 - lo2) + lo2, la1 + (0.5 * (self.height + 2 * self.dy) / self.height * (la2 - la1))), "EPSG:3857")
@@ -170,7 +170,7 @@ class KothicWidget(gtk.DrawingArea):
         from_tile_x, from_tile_y, to_tile_x, to_tile_y = self.tilebox
         dx = 1. * (from_tile_x - int(from_tile_x)) * self.tiles.tilewidth
         dy = 1. * (from_tile_y - int(from_tile_y)) * self.tiles.tileheight
-        print dx, dy
+        print(dx, dy)
         # print self.dx, self.dy
         onscreen_tiles = set()
         for x in range(int(from_tile_x), int(to_tile_x) + 1):
@@ -202,12 +202,13 @@ class TileSource:
         self._singlethread = False
         self._prerender = True
 
-    def __getitem__(self, (z, x, y), wait=False):
+    def __getitem__(self, tile, wait=False):
 
+        (z, x, y) = tile
         try:
             # if "surface" in self.tiles[(z,x,y)] and not wait:
             #  self._callback((z,x,y), True)
-            print "Tiles count:", len(self.tiles)
+            print("Tiles count:", len(self.tiles))
             return self.tiles[(z, x, y)]["surface"]
         except:
             self.tiles[(z, x, y)] = {"tile": RasterTile(self.tilewidth, self.tileheight, z, self.data_backend)}
@@ -226,9 +227,10 @@ class TileSource:
                     self.tiles[(z, x, y)]["thread"].join()
             return self.tiles[(z, x, y)]["surface"]
 
-    def _callback(self, (z, x, y), last):
+    def _callback(self, tile, last):
         # if last:
         #  print last, "dddddddddddddddddd"
+        (z, x, y) = tile
         if not self._singlethread:
             if ((z, x, y) in self.onscreen or last) and "tile" in self.tiles[(z, x, y)]:
                 cr = cairo.Context(self.tiles[(z, x, y)]["surface"])
@@ -276,7 +278,7 @@ class TileSource:
                 if (len(self.tiles) > self.max_tiles):
                     c = cand.pop()
                     try:
-                        print "Killed tile ", c, " - finished in ", str(self.tiles[c]["finish_time"]), ", ago:", str(datetime.datetime.now() - self.tiles[c]["start_time"])
+                        print("Killed tile ", c, " - finished in ", str(self.tiles[c]["finish_time"]), ", ago:", str(datetime.datetime.now() - self.tiles[c]["start_time"]))
                         del self.tiles[c]
                     except KeyError:
                         pass

--- a/src/json_getter.py
+++ b/src/json_getter.py
@@ -1,14 +1,16 @@
 # -*- coding: utf-8 -*-
 from twms import projections
-from libkomapnik import pixel_size_at_zoom
+from .libkomapnik import pixel_size_at_zoom
 import json
 import psycopg2
-from mapcss import MapCSS
+from .mapcss import MapCSS
 import cgi
 import os
 import sys
-reload(sys)
-sys.setdefaultencoding("utf-8")          # a hack to support UTF-8
+import importlib
+importlib.reload(sys)
+if hasattr(sys, "setdefaultencoding"):
+    sys.setdefaultencoding("utf-8")  # a hack to support UTF-8
 
 try:
     import psyco
@@ -167,8 +169,8 @@ def get_vectors(bbox, zoom, style, vec="polygon"):
 
     for row in b.fetchall():
         ROWS_FETCHED += 1
-        geom = dict(map(None, names, row))
-        for t in geom.keys():
+        geom = dict(zip(names, row))
+        for t in list(geom.keys()):
             if not geom[t]:
                 del geom[t]
         geojson = json.loads(geom[geomcolumn])
@@ -179,7 +181,7 @@ def get_vectors(bbox, zoom, style, vec="polygon"):
             geojson["reprpoint"] = json.loads(geom["reprpoint"])["coordinates"]
             del geom["reprpoint"]
         prop = {}
-        for k, v in geom.iteritems():
+        for k, v in geom.items():
             prop[k] = v
             try:
                 if int(v) == float(v):
@@ -195,18 +197,18 @@ def get_vectors(bbox, zoom, style, vec="polygon"):
     return {"bbox": bbox, "granularity": intscalefactor, "features": polygons}
 
 
-print "Content-Type: text/html"
-print
+print("Content-Type: text/html")
+print()
 
 form = cgi.FieldStorage()
 if "z" not in form:
-    print "need z"
+    print("need z")
     exit()
 if "x" not in form:
-    print "need x"
+    print("need x")
     exit()
 if "y" not in form:
-    print "need y"
+    print("need y")
     exit()
 z = int(form["z"].value)
 x = int(form["x"].value)
@@ -226,7 +228,7 @@ aaaa["features"].extend(get_vectors(bbox, zoom, style, "line")["features"])
 aaaa["features"].extend(get_vectors(bbox, zoom, style, "point")["features"])
 
 aaaa = callback + "(" + json.dumps(aaaa, True, False, separators=(',', ':')) + ",%s,%s,%s);" % (z, x, y)
-print aaaa
+print(aaaa)
 
 dir = "/var/www/vtile/%s/%s/" % (z, x)
 file = "%s.js" % y

--- a/src/komap.py
+++ b/src/komap.py
@@ -15,18 +15,20 @@
 #   You should have received a copy of the GNU General Public License
 #   along with kothic.  If not, see <http://www.gnu.org/licenses/>.
 
-from debug import debug, Timer
-from mapcss import MapCSS
+from .debug import debug, Timer
+from .mapcss import MapCSS
 
 import gc
+import importlib
 gc.disable()
 
-import mapcss.webcolors
-whatever_to_hex = mapcss.webcolors.webcolors.whatever_to_hex
+from .mapcss import webcolors
+whatever_to_hex = webcolors.webcolors.whatever_to_hex
 
 import sys
-reload(sys)
-sys.setdefaultencoding("utf-8")
+importlib.reload(sys)
+if hasattr(sys, "setdefaultencoding"):
+    sys.setdefaultencoding("utf-8")
 
 import os
 
@@ -36,11 +38,11 @@ except ImportError:
     pass
 
 from optparse import OptionParser
-import ConfigParser
+import configparser
 import csv
 import math
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 
 
 def relaxedFloat(x):
@@ -109,17 +111,17 @@ if options.renderer == "mapbox-style-language":
     if options.glyphs_url is None:
         parser.error("glyphs url is required")
 
-    from libkomb import *
+    from .libkomb import *
     komap_mapbox(options, style)
     exit()
 
 if options.renderer == "mvt-sql":
-    from mvt_sql import *
+    from .mvt_sql import *
     komap_mvt_sql(options, style)
     exit()
 
 if options.renderer == "mapswithme":
-    from libkomwm import *
+    from .libkomwm import *
     komap_mapswithme(options, style, options.filename)
     exit()
 
@@ -129,11 +131,11 @@ else:
     mfile = open(options.outfile, "w")
 
 if options.renderer == "js":
-    from libkojs import *
+    from .libkojs import *
     komap_js(mfile, style)
 
 if options.renderer == "mapnik":
-    import libkomapnik
+    from . import libkomapnik
 
     config.read(['komap.conf', os.path.expanduser('~/.komap/komap.conf'), options.conffile])
     libkomapnik.map_proj = config.get("mapnik", "map_proj")
@@ -153,7 +155,7 @@ if options.renderer == "mapnik":
     libkomapnik.max_char_angle_delta = config.get("mapnik", "max_char_angle_delta")
     libkomapnik.font_tracking = config.get("mapnik", "font_tracking")
 
-    from libkomapnik import *
+    from .libkomapnik import *
 
     osm2pgsql_avail_keys = {}  # "column" : ["node", "way"]
     if options.osm2pgsqlstyle != "-":
@@ -167,7 +169,7 @@ if options.renderer == "mapnik":
     columnmap = {}
 
     if options.locale == "en":
-        columnmap["name"] = (u"""COALESCE(
+        columnmap["name"] = ("""COALESCE(
         "name:en",
         "int_name",
         replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace
@@ -197,7 +199,7 @@ if options.renderer == "mapnik":
     elif options.locale:
         columnmap["name"] = ("COALESCE(tags->'name:" + options.locale + '\', "name") AS name', ('tags',))
 
-    mapped_cols = [i[0] for i in columnmap.values()]
+    mapped_cols = [i[0] for i in list(columnmap.values())]
     numerics = set()  # set of number-compared things, like "population<10000" needs population as number, not text
     mapniksheet = {}
 
@@ -205,7 +207,7 @@ if options.renderer == "mapnik":
     coast = {}
     fonts = set()
     demhack = False
-    for zoom in xrange(options.minzoom, options.maxzoom + 1):
+    for zoom in range(options.minzoom, options.maxzoom + 1):
         mapniksheet[zoom] = {}
         zsheet = mapniksheet[zoom]
         for chooser in style.choosers:
@@ -284,9 +286,9 @@ if options.renderer == "mapnik":
     for font in fonts:
         mfile.write(xml_fontset(font, True))
 
-    for zoom, zsheet in mapniksheet.iteritems():
+    for zoom, zsheet in mapniksheet.items():
         x_scale = xml_scaledenominator(zoom)
-        ta = zsheet.keys()
+        ta = list(zsheet.keys())
         ta.sort(key=float)
         demcolors = {}
         demramp = {"ground": "", "ocean": ""}
@@ -297,7 +299,7 @@ if options.renderer == "mapnik":
                     if entry["type"] in ("ele",):
                         ele = int(entry["rule"][0][0].params[0])
                         demcolors[ele] = (whatever_to_hex(entry["style"].get('fill-color', '#ffffff')), entry["style"].get('fill-opacity', '1'))
-            dk = demcolors.keys()
+            dk = list(demcolors.keys())
             dk.sort()
             for ele in dk:
                 (color, opacity) = demcolors[ele]
@@ -372,7 +374,7 @@ if options.renderer == "mapnik":
             xml = xml_hillshade(zoom, x_scale)
             mfile.write(xml)
 
-        index_range = range(-6, 7)
+        index_range = list(range(-6, 7))
         full_layering = conf_full_layering
         if (zoom < 9) or not conf_full_layering:
             index_range = (-6, 0, 6)
@@ -415,7 +417,7 @@ if options.renderer == "mapnik":
                                     continue
                                 if zlayer != 6 and entry["style"]["-x-kot-layer"] == "top":
                                     continue
-                            elif zlayer not in range(-5, 6):
+                            elif zlayer not in list(range(-5, 6)):
                                 continue
                             if "casing-width" in entry["style"]:
                                 xml += xml_rule_start()
@@ -485,7 +487,7 @@ if options.renderer == "mapnik":
                                     continue
                                 if zlayer != 6 and entry["style"]["-x-kot-layer"] == "top":
                                     continue
-                            elif zlayer not in range(-5, 6):
+                            elif zlayer not in list(range(-5, 6)):
                                 continue
                             if "width" in entry["style"] or "pattern-image" in entry["style"] or (("fill-color" in entry["style"] or "fill-image" in entry["style"]) and (layer_type == "polygon") and (entry["style"].get("fill-position", "foreground") == "foreground")):
                                 xml += xml_rule_start()
@@ -553,7 +555,7 @@ if options.renderer == "mapnik":
                                                     im.save(icons_path + "komap/" + fname, "PNG")
                                                 xml += xml_linepatternsymbolizer("komap/" + fname)
                                             except:
-                                                print >> sys.stderr, "Error writing to ", icons_path + "komap/" + fname
+                                                print("Error writing to ", icons_path + "komap/" + fname, file=sys.stderr)
                                         else:
                                             if entry["style"].get("-x-kot-render", "none") == "svg":
                                                 xml += xml_linemarkerssymbolizer(entry["style"]["pattern-image"], entry["style"].get("spacing","100"), entry["style"].get("allow-overlap","false"))

--- a/src/libkojs.py
+++ b/src/libkojs.py
@@ -46,7 +46,7 @@ def komap_js(mfile, style):
         styles = ""
         if subclass != "default":
             styles = 'if(!("%s" in style)){style["%s"] = new Object;}' % (subclass, subclass)
-        for k, v in chooser.styles[0].iteritems():
+        for k, v in chooser.styles[0].items():
             if type(v) == str:
                 try:
                     v = str(float(v))

--- a/src/libkomapnik.py
+++ b/src/libkomapnik.py
@@ -18,9 +18,9 @@
 
 import os
 import math
-from debug import debug, Timer
+from .debug import debug, Timer
 
-from mapcss.webcolors.webcolors import whatever_to_hex as nicecolor
+from .mapcss.webcolors.webcolors import whatever_to_hex as nicecolor
 
 
 map_proj = ""
@@ -72,14 +72,14 @@ def pixel_size_at_zoom(z, l=1):
     return int(math.ceil(l * 20037508.342789244 / 256 * 2 / (2 ** z)))
 
 
-def xml_fontset(name, unicode=True):
-    if unicode:
-        unicode = '<Font face-name="unifont Medium" />'
+def xml_fontset(name, str=True):
+    if str:
+        str = '<Font face-name="unifont Medium" />'
     return """
     <FontSet name="%s">
           <Font face-name="%s" />
           %s
-    </FontSet>""" % (name, name, unicode)
+    </FontSet>""" % (name, name, str)
 
 
 def xml_pointsymbolizer(path="", width="", height="", opacity=1, overlap="false"):

--- a/src/libkomb.py
+++ b/src/libkomb.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from mapcss import Condition, _test_feature_compatibility
+from .mapcss import Condition, _test_feature_compatibility
 import json
-import mapcss.webcolors
+from .mapcss import webcolors
 
-whatever_to_hex = mapcss.webcolors.webcolors.whatever_to_hex
+whatever_to_hex = webcolors.webcolors.whatever_to_hex
 
 
 def to_mapbox_condition(condition):
@@ -45,7 +45,7 @@ def to_mapbox_condition(condition):
 
 def to_mapbox_expression(values_by_zoom):
     """ Convert sequence of zoom-value pairs into condensed mapbox expression """
-    values_by_zoom = sorted(values_by_zoom.items(), key=lambda k: k[0])
+    values_by_zoom = sorted(list(values_by_zoom.items()), key=lambda k: k[0])
     j = 0
     for i in range(1, len(values_by_zoom)):
         if values_by_zoom[i][1] != values_by_zoom[i - 1][1]:
@@ -191,7 +191,7 @@ def komap_mapbox(options, style):
         if subject not in ("area", "line", "node"):
             continue
 
-        mapbox_style_layer_filter = ["all"] + map(to_mapbox_condition, conditions)
+        mapbox_style_layer_filter = ["all"] + list(map(to_mapbox_condition, conditions))
         conditions += [
             Condition("set", (c.params[0],))
             for c in conditions
@@ -205,7 +205,7 @@ def komap_mapbox(options, style):
         for zoom in range(0, 24):
             zstyle = get_style(style, subject, conditions, zoom)
 
-            for (prop_name, prop_value) in zstyle.items():
+            for (prop_name, prop_value) in list(zstyle.items()):
                 if prop_name not in zs:
                     zs[prop_name] = {}
                 zs[prop_name][zoom] = prop_value
@@ -228,10 +228,10 @@ def komap_mapbox(options, style):
         break_zs.append(24)
         for (minzoom, maxzoom) in list(zip(break_zs, break_zs[1:])):
             st = {}
-            for (prop_name, prop_value_by_zoom) in zs.items():
+            for (prop_name, prop_value_by_zoom) in list(zs.items()):
                 t = {
                     z: v
-                    for z, v in prop_value_by_zoom.items()
+                    for z, v in list(prop_value_by_zoom.items())
                     if minzoom <= z < maxzoom
                 }
                 if len(t) > 0:
@@ -248,7 +248,7 @@ def komap_mapbox(options, style):
 
         for (minzoom, maxzoom, st) in zzs:
             if st.get("casing-width") and any(
-                v > 0 for v in st.get("casing-width").values()
+                v > 0 for v in list(st.get("casing-width").values())
             ):
                 mapbox_style_layer = {
                     "type": "line",
@@ -263,22 +263,22 @@ def komap_mapbox(options, style):
                 }
 
                 mapbox_style_layer["minzoom"] = sorted(
-                    st.get("casing-width").items(), key=lambda k: k[0]
+                    list(st.get("casing-width").items()), key=lambda k: k[0]
                 )[0][0]
                 mapbox_style_layer["maxzoom"] = (
-                    sorted(st.get("casing-width").items(), key=lambda k: k[0])[-1][0]
+                    sorted(list(st.get("casing-width").items()), key=lambda k: k[0])[-1][0]
                     + 1
                 )
 
                 mapbox_style_layer["paint"]["line-width"] = to_mapbox_expression(
                     {
                         z: v * 2 + st.get("width", {}).get(z, 0)
-                        for z, v in st.get("casing-width").items()
+                        for z, v in list(st.get("casing-width").items())
                     },
                 )
 
                 mapbox_style_layer["paint"]["line-color"] = to_mapbox_expression(
-                    {z: whatever_to_hex(v) for z, v in st.get("casing-color").items()}
+                    {z: whatever_to_hex(v) for z, v in list(st.get("casing-color").items())}
                 )
 
                 if st.get("casing-opacity"):
@@ -289,7 +289,7 @@ def komap_mapbox(options, style):
                     mapbox_style_layer["paint"][
                         "line-dasharray"
                     ] = to_mapbox_expression(
-                        {z: ["literal", v] for z, v in st.get("casing-dashes").items()}
+                        {z: ["literal", v] for z, v in list(st.get("casing-dashes").items())}
                     )
                 if st.get("casing-linecap"):
                     mapbox_style_layer["layout"]["line-cap"] = mapbox_linecaps[
@@ -311,7 +311,7 @@ def komap_mapbox(options, style):
                 mapbox_style_layers.append(mapbox_style_layer)
             if (
                 st.get("width")
-                and any(v > 0 for v in st.get("width").values())
+                and any(v > 0 for v in list(st.get("width").values()))
                 and st.get("color")
             ):
                 mapbox_style_layer = {
@@ -327,10 +327,10 @@ def komap_mapbox(options, style):
                 }
 
                 mapbox_style_layer["minzoom"] = sorted(
-                    st.get("width").items(), key=lambda k: k[0]
+                    list(st.get("width").items()), key=lambda k: k[0]
                 )[0][0]
                 mapbox_style_layer["maxzoom"] = (
-                    sorted(st.get("width").items(), key=lambda k: k[0])[-1][0] + 1
+                    sorted(list(st.get("width").items()), key=lambda k: k[0])[-1][0] + 1
                 )
 
                 mapbox_style_layer["paint"]["line-width"] = to_mapbox_expression(
@@ -338,7 +338,7 @@ def komap_mapbox(options, style):
                 )
 
                 mapbox_style_layer["paint"]["line-color"] = to_mapbox_expression(
-                    {z: whatever_to_hex(v) for z, v in st.get("color").items()}
+                    {z: whatever_to_hex(v) for z, v in list(st.get("color").items())}
                 )
 
                 if st.get("opacity"):
@@ -347,17 +347,17 @@ def komap_mapbox(options, style):
                     )
                 if st.get("blur"):
                     mapbox_style_layer["paint"]["line-blur"] = to_mapbox_expression(
-                        {z: float(v) for z, v in st.get("blur").items()}
+                        {z: float(v) for z, v in list(st.get("blur").items())}
                     )
                 if st.get("dashes"):
                     mapbox_style_layer["paint"][
                         "line-dasharray"
                     ] = to_mapbox_expression(
-                        {z: ["literal", v] for z, v in st.get("dashes").items()}
+                        {z: ["literal", v] for z, v in list(st.get("dashes").items())}
                     )
                 if st.get("linecap"):
                     mapbox_style_layer["layout"]["line-cap"] = to_mapbox_expression(
-                        {z: mapbox_linecaps[v] for z, v in st.get("linecap").items()}
+                        {z: mapbox_linecaps[v] for z, v in list(st.get("linecap").items())}
                     )
                 if st.get("linejoin"):
                     mapbox_style_layer["layout"]["line-join"] = to_mapbox_expression(
@@ -367,7 +367,7 @@ def komap_mapbox(options, style):
                 mapbox_style_layer_id += 1
                 mapbox_style_layers.append(mapbox_style_layer)
             if "fill-color" in st and any(
-                v is not None for v in st.get("fill-color").values()
+                v is not None for v in list(st.get("fill-color").values())
             ):
                 mapbox_style_layer = {
                     "type": "fill",
@@ -381,10 +381,10 @@ def komap_mapbox(options, style):
                 }
 
                 mapbox_style_layer["minzoom"] = sorted(
-                    st.get("fill-color").items(), key=lambda k: k[0]
+                    list(st.get("fill-color").items()), key=lambda k: k[0]
                 )[0][0]
                 mapbox_style_layer["maxzoom"] = (
-                    sorted(st.get("fill-color").items(), key=lambda k: k[0])[-1][0] + 1
+                    sorted(list(st.get("fill-color").items()), key=lambda k: k[0])[-1][0] + 1
                 )
 
                 if st.get("fill-position", "foreground") == "background":
@@ -403,7 +403,7 @@ def komap_mapbox(options, style):
                     )
 
                 mapbox_style_layer["paint"]["fill-color"] = to_mapbox_expression(
-                    {z: whatever_to_hex(v) for z, v in st.get("fill-color").items()}
+                    {z: whatever_to_hex(v) for z, v in list(st.get("fill-color").items())}
                 )
 
                 if st.get("fill-opacity"):
@@ -430,10 +430,10 @@ def komap_mapbox(options, style):
                     ]
 
                 mapbox_style_layer["minzoom"] = sorted(
-                    st.get("text").items(), key=lambda k: k[0]
+                    list(st.get("text").items()), key=lambda k: k[0]
                 )[0][0]
                 mapbox_style_layer["maxzoom"] = (
-                    sorted(st.get("text").items(), key=lambda k: k[0])[-1][0] + 1
+                    sorted(list(st.get("text").items()), key=lambda k: k[0])[-1][0] + 1
                 )
 
                 locales = []
@@ -443,7 +443,7 @@ def komap_mapbox(options, style):
                 if options.label_fallback is not None:
                     fallback = options.label_fallback.split(",")
                 zoom_text = {}
-                for z, v in st.get("text").items():
+                for z, v in list(st.get("text").items()):
                     if v.expr_text == "tag(\"name\")":
                         coalesce = ["coalesce"]
                         for l in locales:
@@ -459,7 +459,7 @@ def komap_mapbox(options, style):
 
                 if st.get("text-position"):
                     symbol_placement = {
-                        z: v for z, v in st.get("text-position").items() if v == "line"
+                        z: v for z, v in list(st.get("text-position").items()) if v == "line"
                     }
                     if len(symbol_placement) > 0:
                         mapbox_style_layer["layout"][
@@ -470,12 +470,12 @@ def komap_mapbox(options, style):
                     mapbox_style_layer["layout"]["text-size"] = to_mapbox_expression(
                         {
                             z: float(v.split(",").pop())
-                            for z, v in st.get("font-size").items()
+                            for z, v in list(st.get("font-size").items())
                         }
                     )
                 if st.get("font-family"):
                     mapbox_style_layer["layout"]["text-font"] = to_mapbox_expression(
-                        {z: ["literal", [v]] for z, v in st.get("font-family").items()}
+                        {z: ["literal", [v]] for z, v in list(st.get("font-family").items())}
                     )
                 if st.get("text-transform"):
                     mapbox_style_layer["layout"][
@@ -487,33 +487,33 @@ def komap_mapbox(options, style):
                     ] = to_mapbox_expression(
                         {
                             z: v == "true"
-                            for z, v in st.get("text-allow-overlap").items()
+                            for z, v in list(st.get("text-allow-overlap").items())
                         }
                     )
                 if st.get("text-offset"):
                     mapbox_style_layer["layout"]["text-offset"] = to_mapbox_expression(
                         {
                             z: ["literal", [0, float(v)]]
-                            for z, v in st.get("text-offset").items()
+                            for z, v in list(st.get("text-offset").items())
                         }
                     )
                 if st.get("text-padding"):
                     mapbox_style_layer["layout"]["text-padding"] = to_mapbox_expression(
-                        {z: float(v) for z, v in st.get("text-padding").items()}
+                        {z: float(v) for z, v in list(st.get("text-padding").items())}
                     )
                 if st.get("text-color"):
                     mapbox_style_layer["paint"]["text-color"] = to_mapbox_expression(
-                        {z: whatever_to_hex(v) for z, v in st.get("text-color").items()}
+                        {z: whatever_to_hex(v) for z, v in list(st.get("text-color").items())}
                     )
                 if st.get("text-opacity"):
                     mapbox_style_layer["paint"]["text-opacity"] = to_mapbox_expression(
-                        {z: float(v) for z, v in st.get("text-opacity").items()}
+                        {z: float(v) for z, v in list(st.get("text-opacity").items())}
                     )
                 if st.get("text-halo-radius"):
                     mapbox_style_layer["paint"][
                         "text-halo-width"
                     ] = to_mapbox_expression(
-                        {z: float(v) for z, v in st.get("text-halo-radius").items()}
+                        {z: float(v) for z, v in list(st.get("text-halo-radius").items())}
                     )
                 if st.get("text-halo-color"):
                     mapbox_style_layer["paint"][
@@ -521,7 +521,7 @@ def komap_mapbox(options, style):
                     ] = to_mapbox_expression(
                         {
                             z: whatever_to_hex(v)
-                            for z, v in st.get("text-halo-color").items()
+                            for z, v in list(st.get("text-halo-color").items())
                         }
                     )
 
@@ -535,4 +535,4 @@ def komap_mapbox(options, style):
 
     mapbox_style["layers"] = sorted(mapbox_style["layers"], key=lambda k: k["priority"])
 
-    print(json.dumps(mapbox_style))
+    print((json.dumps(mapbox_style)))

--- a/src/libkomwm.py
+++ b/src/libkomwm.py
@@ -1,19 +1,19 @@
-from drules_struct_pb2 import *
-import texture_packer
+from .drules_struct_pb2 import *
+from . import texture_packer
 
 
 import os
 import csv
 import json
-import mapcss.webcolors
-whatever_to_hex = mapcss.webcolors.webcolors.whatever_to_hex
-whatever_to_cairo = mapcss.webcolors.webcolors.whatever_to_cairo
+from .mapcss import webcolors
+whatever_to_hex = webcolors.webcolors.whatever_to_hex
+whatever_to_cairo = webcolors.webcolors.whatever_to_cairo
 
 WIDTH_SCALE = 1.0
 
 def komap_mapswithme(options, style, filename):
     if options.outfile == "-":
-        print "Please specify base output path."
+        print("Please specify base output path.")
         exit()
     else:
         ddir = os.path.dirname(options.outfile)
@@ -45,13 +45,13 @@ def komap_mapswithme(options, style, filename):
         classificator[row[0].replace("|", "-")] = kv
         if row[2] != "x":
             class_order.append(row[0].replace("|", "-"))
-            print >> types_file, row[0]
+            print(row[0], file=types_file)
         else:
             # compatibility mode
             if row[6]:
-                print >> types_file, row[6]
+                print(row[6], file=types_file)
             else:
-                print >> types_file, "mapswithme"
+                print("mapswithme", file=types_file)
         class_tree[row[0].replace("|", "-")] = row[0]
     class_order.sort()
     types_file.close()
@@ -107,7 +107,7 @@ def komap_mapswithme(options, style, filename):
         dr_cont = ClassifElementProto()
         dr_cont.name = cl
 
-        for zoom in xrange(options.minzoom, options.maxzoom + 1):
+        for zoom in range(options.minzoom, options.maxzoom + 1):
             txclass = classificator[cl]
             txclass["name"] = "name"
             txclass["addr:housenumber"] = "addr:housenumber"
@@ -125,7 +125,7 @@ def komap_mapswithme(options, style, filename):
 
             if True:
                 areastyle = style.get_style_dict("area", txclass, zoom, olddict=zstyle, cache=False)
-                for st in areastyle.values():
+                for st in list(areastyle.values()):
                     if "icon-image" in st or 'symbol-shape' in st or 'symbol-image' in st:
                         has_icons_for_areas = True
                 zstyle = areastyle
@@ -136,13 +136,13 @@ def komap_mapswithme(options, style, filename):
                 #    if "fill-color" in st:
                 #        del st["fill-color"]
                 zstyle = nodestyle
-            zstyle = zstyle.values()
+            zstyle = list(zstyle.values())
             has_lines = False
             has_text = []
             has_icons = False
             has_fills = False
             for st in zstyle:
-                st = dict([(k, v) for k, v in st.iteritems() if str(v).strip(" 0.")])
+                st = dict([(k, v) for k, v in st.items() if str(v).strip(" 0.")])
                 if 'width' in st or 'pattern-image' in st:
                     has_lines = True
                 if 'icon-image' in st or 'symbol-shape' in st or 'symbol-image' in st:
@@ -270,22 +270,22 @@ def komap_mapswithme(options, style, filename):
     prevvis = []
     visnodes = set()
     drules_bin.write(drules.SerializeToString())
-    drules_txt.write(unicode(drules))
+    drules_txt.write(str(drules))
 
     gui_symbol_path = os.path.join(ddir, 'symbols')
     imgpaths = [(".".join(i.split(".")[:-1]), {"file": os.path.join(gui_symbol_path, i)}, 24) for i in os.listdir(gui_symbol_path)]
-    imgpaths.extend([(handle, svg, 18) for handle, svg in textures.iteritems()])
+    imgpaths.extend([(handle, svg, 18) for handle, svg in textures.items()])
     dpiset = [('ldpi', 0.75), ('mdpi', 1), ('hdpi', 1.5), ('xhdpi', 2), ('xxhdpi', 3), ('yota', 1)]
-    style_dpi = style.get_style_dict("canvas", {}, 0).values()[0].get("-x-mapsithme-dpi", "ldpi,mdpi,hdpi,xhdpi,xxhdpi").split(",")
+    style_dpi = list(style.get_style_dict("canvas", {}, 0).values())[0].get("-x-mapsithme-dpi", "ldpi,mdpi,hdpi,xhdpi,xxhdpi").split(",")
     for (dpiname, multiplier) in dpiset:
         if dpiname in style_dpi:
             texture_packer.pack_texture(imgpaths, multiplier, os.path.join(ddir, 'resources-'+dpiname))
 
-    for k, v in visibility.iteritems():
+    for k, v in visibility.items():
         vis = k.split("|")
         for i in range(1, len(vis) - 1):
             visnodes.add("|".join(vis[0:i]) + "|")
-    viskeys = list(set(visibility.keys() + list(visnodes)))
+    viskeys = list(set(list(visibility.keys()) + list(visnodes)))
 
     def cmprepl(a, b):
         if a == b:
@@ -304,15 +304,15 @@ def komap_mapswithme(options, style, filename):
     for k in viskeys:
         offset = "    " * (k.count("|") - 1)
         for i in range(len(oldoffset) / 4, len(offset) / 4, -1):
-            print >>visibility_file, "    " * i + "{}"
-            print >>classificator_file, "    " * i + "{}"
+            print("    " * i + "{}", file=visibility_file)
+            print("    " * i + "{}", file=classificator_file)
 
         oldoffset = offset
         end = "-"
         if k in visnodes:
             end = "+"
-        print >>visibility_file, offset + k.split("|")[-2] + "  " + visibility.get(k, "0" * (options.maxzoom + 1)) + "  " + end
-        print >>classificator_file, offset + k.split("|")[-2] + "  " + end
+        print(offset + k.split("|")[-2] + "  " + visibility.get(k, "0" * (options.maxzoom + 1)) + "  " + end, file=visibility_file)
+        print(offset + k.split("|")[-2] + "  " + end, file=classificator_file)
     for i in range(len(offset) / 4, 0, -1):
-        print >>visibility_file, "    " * i + "{}"
-        print >>classificator_file, "    " * i + "{}"
+        print("    " * i + "{}", file=visibility_file)
+        print("    " * i + "{}", file=classificator_file)

--- a/src/make_postgis_style.py
+++ b/src/make_postgis_style.py
@@ -17,14 +17,14 @@
 
 import sys
 
-from debug import debug, Timer
-from mapcss import MapCSS
+from .debug import debug, Timer
+from .mapcss import MapCSS
 
 
 langs = ['int_name', 'name:af', 'name:am', 'name:ar', 'name:be', 'name:bg', 'name:br', 'name:ca', 'name:cs', 'name:cy', 'name:de', 'name:el', 'name:en', 'name:eo', 'name:es', 'name:et', 'name:eu', 'name:fa', 'name:fi', 'name:fr', 'name:fur', 'name:fy', 'name:ga', 'name:gd', 'name:gsw', 'name:he', 'name:hi', 'name:hr', 'name:hsb', 'name:hu', 'name:hy', 'name:it', 'name:ja', 'name:ja_kana', 'name:ja_rm', 'name:ka', 'name:kk', 'name:kn', 'name:ko', 'name:ko_rm', 'name:ku', 'name:la', 'name:lb', 'name:lt', 'name:lv', 'name:mk', 'name:mn', 'name:nl', 'name:pl', 'name:pt', 'name:ro', 'name:ru', 'name:sk', 'name:sl', 'name:sq', 'name:sr', 'name:sv', 'name:th', 'name:tr', 'name:uk', 'name:vi', 'name:zh', 'name:zh_pinyin']
 
 if len(sys.argv) < 2:
-    print "Usage: make_postgis_style.py [stylesheet] [additional_tag,tag2,tag3]"
+    print("Usage: make_postgis_style.py [stylesheet] [additional_tag,tag2,tag3]")
     exit()
 
 style = MapCSS(1, 19)  # zoom levels
@@ -44,13 +44,13 @@ for a in t:
             dct[tag] = set()
         dct[tag].add(t[a])
 
-print """
-# OsmType  Tag                DataType      Flags"""
+print("""
+# OsmType  Tag                DataType      Flags""")
 for t in ("z_order", "way_area", ":area"):
     if t in dct:
         del dct[t]
 
-keys = dct.keys()
+keys = list(dct.keys())
 keys.sort()
 
 for k in keys:
@@ -59,7 +59,7 @@ for k in keys:
     pol = "linear"
     if "polygon" in set([i[1] for i in v]):
         pol = "polygon"
-    print "%-10s %-20s %-13s %s" % (s, k, "text", pol)
-print """
+    print("%-10s %-20s %-13s %s" % (s, k, "text", pol))
+print("""
 node,way   z_order              int4          linear # This is calculated during import
-way        way_area             real                 # This is calculated during import"""
+way        way_area             real                 # This is calculated during import""")

--- a/src/mapcss/Condition.py
+++ b/src/mapcss/Condition.py
@@ -19,7 +19,7 @@ import re
 
 INVERSIONS = {"eq": "ne", "true": "false", "set": "unset", "<": ">=", ">": "<="}
 in2 = {}
-for a, b in INVERSIONS.iteritems():
+for a, b in INVERSIONS.items():
     in2[b] = a
 INVERSIONS.update(in2)
 del in2

--- a/src/mapcss/Eval.py
+++ b/src/mapcss/Eval.py
@@ -78,7 +78,7 @@ class Eval():
         """
         Compute this eval()
         """
-        for k, v in tags.iteritems():
+        for k, v in tags.items():
             try:
                 tag[k] = float(v)
             except:
@@ -189,6 +189,6 @@ def m_metric(x, t):
 
 if __name__ == "__main__":
     a = Eval(""" eval( any( metric(tag("height")), metric ( num(tag("building:levels")) * 3), metric("1m"))) """)
-    print repr(a)
-    print a.compute({"building:levels": "3"})
-    print a.extract_tags()
+    print(repr(a))
+    print(a.compute({"building:levels": "3"}))
+    print(a.extract_tags())

--- a/src/mapcss/Rule.py
+++ b/src/mapcss/Rule.py
@@ -15,7 +15,7 @@
 #   You should have received a copy of the GNU General Public License
 #   along with kothic.  If not, see <http://www.gnu.org/licenses/>.
 
-from Condition import Condition
+from .Condition import Condition
 
 type_matches = {
     "": ('area', 'line', 'way', 'node'),

--- a/src/mapcss/StyleChooser.py
+++ b/src/mapcss/StyleChooser.py
@@ -16,15 +16,15 @@
 #   along with kothic.  If not, see <http://www.gnu.org/licenses/>.
 
 
-from Rule import Rule
-from webcolors.webcolors import whatever_to_cairo as colorparser
-from webcolors.webcolors import cairo_to_hex
-from Eval import Eval
+from .Rule import Rule
+from .webcolors.webcolors import whatever_to_cairo as colorparser
+from .webcolors.webcolors import cairo_to_hex
+from .Eval import Eval
 
 
 def make_nice_style(r):
     ra = {}
-    for a, b in r.iteritems():
+    for a, b in r.items():
         "checking and nicifying style table"
         if type(b) == type(Eval()):
             ra[a] = b
@@ -119,7 +119,7 @@ class StyleChooser:
         
         if tags:  # FIXME: semi-illegal optimization, may wreck in future on tagless matches
             for r in self.styles:
-                for c, b in r.iteritems():
+                for c, b in r.items():
                     if type(b) == self.eval_type:
                         tags.update(b.extract_tags())
         
@@ -136,7 +136,7 @@ class StyleChooser:
                 a.update(r.get_interesting_tags(ztype, zoom))
         if a:  # FIXME: semi-illegal optimization, may wreck in future on tagless matches
             for r in self.styles:
-                for c, b in r.iteritems():
+                for c, b in r.items():
                     if type(b) == self.eval_type:
                         a.update(b.extract_tags())
         return a
@@ -180,13 +180,13 @@ class StyleChooser:
         for r in self.styles:
             if self.has_evals:
                 ra = {}
-                for a, b in r.iteritems():
+                for a, b in r.items():
                     "calculating eval()'s"
                     if type(b) == self.eval_type:
                         combined_style = {}
                         for t in sl:
                             combined_style.update(t)
-                        for p, q in combined_style.iteritems():
+                        for p, q in combined_style.items():
                             if "color" in p:
                                 combined_style[p] = cairo_to_hex(q)
                         b = b.compute(tags, combined_style, scale, zscale)
@@ -269,7 +269,7 @@ class StyleChooser:
         rb = []
         for r in a:
             ra = {}
-            for a, b in r.iteritems():
+            for a, b in r.items():
                 a = a.strip()
                 b = b.strip()
                 if a == "casing-width":

--- a/src/mapcss/__init__.py
+++ b/src/mapcss/__init__.py
@@ -23,9 +23,9 @@ from hashlib import md5
 from copy import copy, deepcopy
 
 
-from StyleChooser import StyleChooser
-from Condition import Condition
-from Rule import _test_feature_compatibility
+from .StyleChooser import StyleChooser
+from .Condition import Condition
+from .Rule import _test_feature_compatibility
 
 
 NEEDED_KEYS = set(["width", "casing-width", "fill-color", "fill-image", "icon-image", "text", "extrude", "background-image", "background-color", "pattern-image", "shield-text", "symbol-shape"])
@@ -120,7 +120,7 @@ class MapCSS():
         Kothic styling API
         """
         if cache:
-            shash = md5(repr(type) + repr(tags) + repr(zoom)).digest()
+            shash = md5((repr(type) + repr(tags) + repr(zoom)).encode("utf-8")).digest()
             if shash in self.cache["style"]:
                 return deepcopy(self.cache["style"][shash])
         style = []
@@ -186,7 +186,7 @@ class MapCSS():
 
     def subst_variables(self, t):
         """Expects an array from parseDeclaration."""
-	for k in t[0]:
+        for k in t[0]:
             t[0][k] = VARIABLE.sub(self.get_variable, t[0][k])
         return t
 
@@ -303,7 +303,7 @@ class MapCSS():
                     import_text = open(filename, "r").read().strip()
                     css = import_text + css
                 except IOError as e:
-			log.warning("cannot import file %s: %s" % (filename, e))
+                    log.warning("cannot import file %s: %s" % (filename, e))
 
             elif VARIABLE_SET.match(css):
                 name = VARIABLE_SET.match(css).groups()[0]
@@ -314,7 +314,7 @@ class MapCSS():
 
             # Unknown pattern
             elif UNKNOWN.match(css):
-                log.warning("unknown thing found on line %s: %s" % (unicode(css_orig[:-len(unicode(css))]).count("\n") + 1, UNKNOWN.match(css).group()))
+                log.warning("unknown thing found on line %s: %s" % (str(css_orig[:-len(str(css))]).count("\n") + 1, UNKNOWN.match(css).group()))
                 css = UNKNOWN.sub("", css)
 
             else:

--- a/src/mapcss/webcolors/webcolors.py
+++ b/src/mapcss/webcolors/webcolors.py
@@ -198,7 +198,7 @@ def _reversedict(d):
     dictionary, returns a new dictionary with keys and values swapped.
 
     """
-    return dict(zip(d.values(), d.keys()))
+    return dict(list(zip(list(d.values()), list(d.keys()))))
 
 HEX_COLOR_RE = re.compile(r'^#([a-fA-F0-9]|[a-fA-F0-9]{3}|[a-fA-F0-9]{6})$')
 
@@ -454,7 +454,7 @@ def normalize_hex(hex_value):
     except AttributeError:
         raise ValueError("'%s' is not a valid hexadecimal color value." % hex_value)
     if len(hex_digits) == 3:
-        hex_digits = ''.join(map(lambda s: 2 * s, hex_digits))
+        hex_digits = ''.join([2 * s for s in hex_digits])
     elif len(hex_digits) == 1:
         hex_digits = hex_digits * 6
     return '#%s' % hex_digits.lower()
@@ -648,8 +648,7 @@ def hex_to_rgb(hex_value):
 
     """
     hex_digits = normalize_hex(hex_value)
-    return tuple(map(lambda s: int(s, 16),
-                     (hex_digits[1:3], hex_digits[3:5], hex_digits[5:7])))
+    return tuple([int(s, 16) for s in (hex_digits[1:3], hex_digits[3:5], hex_digits[5:7])])
 
 
 def hex_to_rgb_percent(hex_value):
@@ -716,7 +715,8 @@ def rgb_to_hex(rgb_triplet):
     '#2138c0'
 
     """
-    return '#%02x%02x%02x' % rgb_triplet
+    r, g, b = rgb_triplet
+    return '#%02x%02x%02x' % (int(round(r)), int(round(g)), int(round(b)))
 
 
 def rgb_to_rgb_percent(rgb_triplet):
@@ -750,8 +750,7 @@ def rgb_to_rgb_percent(rgb_triplet):
     # from 0 through 4, as well as 0 itself.
     specials = {255: '100%', 128: '50%', 64: '25%',
                 32: '12.5%', 16: '6.25%', 0: '0%'}
-    return tuple(map(lambda d: specials.get(d, '%.02f%%' % ((d / 255.0) * 100)),
-                     rgb_triplet))
+    return tuple([specials.get(d, '%.02f%%' % ((d / 255.0) * 100)) for d in rgb_triplet])
 
 
 ######################################################################

--- a/src/mvt_sql.py
+++ b/src/mvt_sql.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 import sys
 import math
-from mapcss import _test_feature_compatibility
+from .mapcss import _test_feature_compatibility
+import importlib
 
-reload(sys)
-sys.setdefaultencoding("utf-8")  # a hack to support UTF-8
+importlib.reload(sys)
+if hasattr(sys, "setdefaultencoding"):
+    sys.setdefaultencoding("utf-8")  # a hack to support UTF-8
 
 mapped_cols = {}
 osm2pgsql_avail_keys = {}
@@ -163,7 +165,7 @@ def get_vectors(minzoom, maxzoom, x, y, style, vec, extent, locales):
         'bIa'), 'bе', 'bie'), 'bё', 'bio'), 'bю', 'biu'), 'bя', 'bia'), 'vЕ', 'vIe'), 'vЁ', 'vIo'), 'vЮ', 'vIu'), 'vЯ', 'vIa'), 'vе', 'vie'), 'vё', 'vio'), 'vю', 'viu'), 'vя', 'via'), 'hЕ', 'hIe'), 'hЁ', 'hIo'), 'hЮ', 'hIu'), 'hЯ', 'hIa'), 'hе', 'hie'), 'hё', 'hio'), 'hю', 'hiu'), 'hя', 'hia'), 'dЕ', 'dIe'), 'dЁ', 'dIo'), 'dЮ', 'dIu'), 'dЯ', 'dIa'), 'dе', 'die'), 'dё', 'dio'), 'dю', 'diu'), 'dя', 'dia'), 'žЕ', 'žIe'), 'žЁ', 'žIo'), 'žЮ', 'žIu'), 'žЯ', 'žIa'), 'žе', 'žie'), 'žё', 'žio'), 'žю', 'žiu'), 'žя', 'žia'), 'zЕ', 'zIe'), 'zЁ', 'zIo'), 'zЮ', 'zIu'), 'zЯ', 'zIa'), 'zе', 'zie'), 'zё', 'zio'), 'zю', 'ziu'), 'zя', 'zia'), 'jЕ', 'jIe'), 'jЁ', 'jIo'), 'jЮ', 'jIu'), 'jЯ', 'jIa'), 'jе', 'jie'), 'jё', 'jio'), 'jю', 'jiu'), 'jя', 'jia'), 'кЕ', 'кIe'), 'кЁ', 'кIo'), 'кЮ', 'кIu'), 'кЯ', 'кIa'), 'ке', 'кie'), 'кё', 'кio'), 'кю', 'кiu'), 'кя', 'кia'), 'lЕ', 'lIe'),
         'lЁ', 'lIo'), 'lЮ', 'lIu'), 'lЯ', 'lIa'), 'lе', 'lie'), 'lё', 'lio'), 'lю', 'liu'), 'lя', 'lia'), 'mЕ', 'mIe'), 'mЁ', 'mIo'), 'mЮ', 'mIu'), 'mЯ', 'mIa'), 'mе', 'mie'), 'mё', 'mio'), 'mю', 'miu'), 'mя', 'mia'), 'nЕ', 'nIe'), 'nЁ', 'nIo'), 'nЮ', 'nIu'), 'nЯ', 'nIa'), 'nе', 'nie'), 'nё', 'nio'), 'nю', 'niu'), 'nя', 'nia'), 'pЕ', 'pIe'), 'pЁ', 'pIo'), 'pЮ', 'pIu'), 'pЯ', 'pIa'), 'pе', 'pie'), 'pё', 'pio'), 'pю', 'piu'), 'pя', 'pia'), 'rЕ', 'rIe'), 'rЁ', 'rIo'), 'rЮ', 'rIu'), 'rЯ', 'rIa'), 'rе', 'rie'), 'rё', 'rio'), 'rю', 'riu'), 'rя', 'ria'), 'sЕ', 'sIe'), 'sЁ',
         'sIo'), 'sЮ', 'sIu'), 'sЯ', 'sIa'), 'sе', 'sie'), 'sё', 'sio'), 'sю', 'siu'), 'sя', 'sia'), 'tЕ', 'tIe'), 'tЁ', 'tIo'), 'tЮ', 'tIu'), 'tЯ', 'tIa'), 'tе', 'tie'), 'tё', 'tio'), 'tю', 'tiu'), 'tя', 'tia'), 'ŭЕ', 'ŭIe'), 'ŭЁ', 'ŭIo'), 'ŭЮ', 'ŭIu'), 'ŭЯ', 'ŭIa'), 'ŭе', 'ŭie'), 'ŭё', 'ŭio'), 'ŭю', 'ŭiu'), 'ŭя', 'ŭia'), 'fЕ', 'fIe'), 'fЁ', 'fIo'), 'fЮ', 'fIu'), 'fЯ', 'fIa'), 'fе', 'fie'), 'fё', 'fio'), 'fю', 'fiu'), 'fя', 'fia'), 'сЕ', 'сIe'), 'сЁ', 'сIo'), 'сЮ', 'сIu'), 'сЯ', 'сIa'), 'се', 'сie'), 'сё', 'сio'), 'сю', 'сiu'), 'ся', 'сia'), 'čЕ', 'čIe'), 'čЁ', 'čIo'), 'čЮ', 'čIu'), 'čЯ', 'čIa'), 'čе', 'čie'), 'čё',
-        'čio'), 'čю', 'čiu'), 'čя', 'čia'), 'šЕ', 'šIe'), 'šЁ', 'šIo'), 'šЮ', 'šIu'), 'šЯ', 'šIa'), 'šе', 'šie'), 'šё', 'šio'), 'šю', 'šiu'), 'šя', 'šia'), 'Е', 'Je'), 'Ё', 'Jo'), 'Ю', 'Ju'), 'Я', 'Ja'), 'е', 'je'), 'ё', 'jo'), 'ю', 'ju'), 'я', 'ja'), 'Ь', E'\u0301'), 'ь', E'\u0301'),'’', ''),
+        'čio'), 'čю', 'čiu'), 'čя', 'čia'), 'šЕ', 'šIe'), 'šЁ', 'šIo'), 'šЮ', 'šIu'), 'šЯ', 'šIa'), 'šе', 'šie'), 'šё', 'šio'), 'šю', 'šiu'), 'šя', 'šia'), 'Е', 'Je'), 'Ё', 'Jo'), 'Ю', 'Ju'), 'Я', 'Ja'), 'е', 'je'), 'ё', 'jo'), 'ю', 'ju'), 'я', 'ja'), 'Ь', E'\\u0301'), 'ь', E'\\u0301'),'’', ''),
         replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(translate(tags->'name:ru','абвгдезиклмнопрстуфьАБВГДЕЗИКЛМНОПРСТУФЬ','abvgdeziklmnoprstuf’ABVGDEZIKLMNOPRSTUF’'),'х','kh'),'Х','Kh'),'ц','ts'),'Ц','Ts'),'ч','ch'),'Ч','Ch'),'ш','sh'),'Ш','Sh'),'щ','shch'),'Щ','Shch'),'ъ','”'),'Ъ','”'),'ё','yo'),'Ё','Yo'),'ы','y'),'Ы','Y'),'э','·e'),'Э','E'),'ю','yu'),'Ю','Yu'),'й','y'),'Й','Y'),'я','ya'),'Я','Ya'),'ж','zh'),'Ж','Zh'))"""
 
     adp = " OR ".join(adp)
@@ -391,7 +393,7 @@ def komap_mvt_sql(options, style):
                 osm2pgsql_avail_keys[line[1]] = tuple(line[0].split(","))
         osm2pgsql_avail_keys["tags"] = ("node", "way")
 
-    print(
+    print((
         """select
         case when $1 = 0 then %s
              when $1 = 1 then %s
@@ -427,4 +429,4 @@ def komap_mvt_sql(options, style):
             basemap_sql(13, 13, 4096, style, options),
             basemap_sql(14, 23, 8192, style, options),
         )
-    )
+    ))

--- a/src/osm2tiles.py
+++ b/src/osm2tiles.py
@@ -20,10 +20,12 @@ import sqlite3
 import sys
 from lxml import etree
 from twms import projections
-from style import Styling
+from .style import Styling
+import importlib
 
-reload(sys)
-sys.setdefaultencoding("utf-8")          # a hack to support UTF-8
+importlib.reload(sys)
+if hasattr(sys, "setdefaultencoding"):
+    sys.setdefaultencoding("utf-8")  # a hack to support UTF-8
 
 try:
     import psyco
@@ -47,16 +49,16 @@ def tilelist_by_geometry(way, start_zoom=0, ispoly=False):
     """
     ret = set([])
     tiles_by_zooms = {}  # zoom: set(tile,tile,tile...)
-    for t in xrange(0, MAXZOOM + 1):
+    for t in range(0, MAXZOOM + 1):
         tiles_by_zooms[t] = set([])
     for point in way:
         tile = projections.tile_by_coords(point, MAXZOOM, proj)
         tile = (MAXZOOM, int(tile[0]), int(tile[1]))
         tiles_by_zooms[MAXZOOM].add(tile)
-    for t in xrange(MAXZOOM - 1, start_zoom - 1, -1):
+    for t in range(MAXZOOM - 1, start_zoom - 1, -1):
         for tt in tiles_by_zooms[t + 1]:
             tiles_by_zooms[t].add((t, int(tt[1] / 2), int(tt[2] / 2)))
-    for z in tiles_by_zooms.values():
+    for z in list(tiles_by_zooms.values()):
         ret.update(z)
     return ret
 
@@ -74,7 +76,7 @@ def sanitize(string):
     string = string.replace("=", "###")
     return string
 
-print sanitize(" ;=")
+print(sanitize(" ;="))
 
 
 def initDB(filename):
@@ -120,15 +122,15 @@ def main():
     tags = {}
     context = etree.iterparse(osm_infile)
     for action, elem in context:
-        items = dict(elem.items())
+        items = dict(list(elem.items()))
         if elem.tag == "node":
             NODES_READ += 1
             if NODES_READ % 10000 == 0:
-                print "Nodes read:", NODES_READ
-                print len(curway), len(tags), len(tilefiles), len(tilefiles_hist)
+                print("Nodes read:", NODES_READ)
+                print(len(curway), len(tags), len(tilefiles), len(tilefiles_hist))
             if NODES_READ % 100000 == 0:
                 conn.commit()
-                print "flushing to temporary storage"
+                print("flushing to temporary storage")
 
 #      nodes[str(items["id"])] = (float(items["lon"]), float(items["lat"]))
             storeNode(conn, int(items["id"]), float(items["lon"]), float(items["lat"]))
@@ -146,17 +148,17 @@ def main():
         elif elem.tag == "way":
             WAYS_READ += 1
             if WAYS_READ % 1000 == 0:
-                print "Ways read:", WAYS_READ
+                print("Ways read:", WAYS_READ)
 
             mzoom = 1
             # tags = style.filter_tags(tags)
             if tags:
                 if True:  # style.get_style("way", tags, True):            # if way is stylized
-                    towrite = ";".join(["%s=%s" % x for x in tags.iteritems()])  # TODO: sanitize keys and values
+                    towrite = ";".join(["%s=%s" % x for x in tags.items()])  # TODO: sanitize keys and values
                     # print towrite
                     way_simplified = {MAXZOOM: curway}
 
-                    for zoom in xrange(MAXZOOM - 1, -1, -1):  # generalize a bit
+                    for zoom in range(MAXZOOM - 1, -1, -1):  # generalize a bit
                                           # TODO: Douglas-Peucker
                         prev_point = curway[0]
                         way = [prev_point]
@@ -189,9 +191,9 @@ def main():
                                 tilefiles_hist.append(tile)
                         tilefiles_hist.remove(tile)
                         tilefiles_hist.append(tile)
-                        print >>tilefiles[tile], "%s %s" % (towrite, items["id"]), " ".join([str(x[0]) + " " + str(x[1]) for x in way_simplified[tile[0]]])
+                        print("%s %s" % (towrite, items["id"]), " ".join([str(x[0]) + " " + str(x[1]) for x in way_simplified[tile[0]]]), file=tilefiles[tile])
                         if len(tilefiles_hist) > 400:
-                            print "Cleaned up tiles. Wrote by now:", len(tilefiles), "active:", len(tilefiles_hist)
+                            print("Cleaned up tiles. Wrote by now:", len(tilefiles), "active:", len(tilefiles_hist))
                             for tile in tilefiles_hist[0:len(tilefiles_hist) - 100]:
 
                                 tilefiles_hist.remove(tile)
@@ -202,7 +204,7 @@ def main():
                 # print >>corr, "%s %s %s %s %s %s"% (curway[0][0],curway[0][1],curway[1][0],curway[1][1], user, ts )
                 WAYS_WRITTEN += 1
                 if WAYS_WRITTEN % 10000 == 0:
-                    print WAYS_WRITTEN
+                    print(WAYS_WRITTEN)
             curway = []
             tags = {}
         elem.clear()
@@ -210,15 +212,15 @@ def main():
         del elem
                 # user = default_user
                 # ts = ""
-    print "Tiles generated:", len(tilefiles)
-    print "Nodes dropped when generalizing:", DROPPED_POINTS
+    print("Tiles generated:", len(tilefiles))
+    print("Nodes dropped when generalizing:", DROPPED_POINTS)
 #  print "Nodes in memory:", len(nodes)
     c = conn.cursor()
     c.execute('SELECT * from nodes')
-    print "Nodes in memory:", len(c.fetchall())
+    print("Nodes in memory:", len(c.fetchall()))
 
     # report temporary file size
-    print "Temporary file size:", os.path.getsize(TEMPORARY_FILE_PATH)
+    print("Temporary file size:", os.path.getsize(TEMPORARY_FILE_PATH))
 
     # remove temporary files
     os.remove(TEMPORARY_FILE_PATH)

--- a/src/render.py
+++ b/src/render.py
@@ -15,7 +15,7 @@
 #   You should have received a copy of the GNU General Public License
 #   along with kothic.  If not, see <http://www.gnu.org/licenses/>.
 
-from debug import debug, Timer
+from .debug import debug, Timer
 from twms import projections
 import cairo
 import math
@@ -77,7 +77,8 @@ class RasterTile:
         return projections.to4326((1. * x / self.w * (lo2 - lo1) + lo1, la2 + (1. * y / (self.h) * (la1 - la2))), self.proj)
     #  return (x - self.w/2)/(math.cos(self.center_coord[1]*math.pi/180)*self.zoom) + self.center_coord[0], -(y - self.h/2)/self.zoom + self.center_coord[1]
 
-    def lonlat2screen(self, (lon, lat), epsg4326=False):
+    def lonlat2screen(self, lonlat, epsg4326=False):
+        (lon, lat) = lonlat
         if epsg4326:
             lon, lat = projections.from4326((lon, lat), self.proj)
         lo1, la1, lo2, la2 = self.bbox_p
@@ -103,7 +104,7 @@ class RasterTile:
         self.bbox = bbox
         self.bbox_p = projections.from4326(bbox, self.proj)
 
-        print self.bbox_p
+        print(self.bbox_p)
         scale = abs(self.w / (self.bbox_p[0] - self.bbox_p[2]) / math.cos(math.pi * (self.bbox[1] + self.bbox[3]) / 2 / 180))
         zscale = 0.5 * scale
         cr = cairo.Context(self.surface)
@@ -147,7 +148,7 @@ class RasterTile:
         # enlarge bbox by 20% to each side. results in more vectors, but makes less artifaces.
         span_x, span_y = bbox[2] - bbox[0], bbox[3] - bbox[1]
         bbox_expand = [bbox[0] - 0.2 * span_x, bbox[1] - 0.2 * span_y, bbox[2] + 0.2 * span_x, bbox[3] + 0.2 * span_y]
-        vectors = self.data.get_vectors(bbox_expand, self.zoom, hints, itags).values()
+        vectors = list(self.data.get_vectors(bbox_expand, self.zoom, hints, itags).values())
         datatimer.stop()
         datatimer = Timer("Applying styles")
         ww = []
@@ -319,8 +320,8 @@ class RasterTile:
                     return -1
 
                 return cmp(math.sin(math.atan2(a[0][0][0] - a[0][1][0], a[0][0][0] - a[0][1][0])), math.sin(math.atan2(b[0][0][0] - b[0][1][0], b[0][0][0] - b[0][1][0])))
-                print t1
-                print t2
+                print(t1)
+                print(t2)
 
             extlist.sort(compare_things)
 
@@ -434,7 +435,7 @@ class RasterTile:
                             cr.fill()
                     else:  # render text along line
                         c = obj[0].cs
-                        text = unicode(text, "utf-8")
+                        text = str(text, "utf-8")
                         # - calculate line length
                         length = reduce(lambda x, y: (x[0] + ((y[0] - x[1]) ** 2 + (y[1] - x[2]) ** 2) ** 0.5, y[0], y[1]), c, (0, c[0][0], c[0][1]))[0]
                         # print length, text, cr.text_extents(text)
@@ -536,7 +537,7 @@ class ImageLoader:
         if url in self.cache:
             return self.cache[url]
         else:
-            print url, os_module.path.exists(url)
+            print(url, os_module.path.exists(url))
             if os_module.path.exists(url):
                 self.cache[url] = cairo.ImageSurface.create_from_png(url)
                 return self.cache[url]

--- a/src/simple_wms.py
+++ b/src/simple_wms.py
@@ -16,13 +16,13 @@
 #   along with kothic.  If not, see <http://www.gnu.org/licenses/>.
 
 
-from debug import debug, Timer
-from backend.postgis import PostGisBackend as DataBackend
-from mapcss import MapCSS
+from .debug import debug, Timer
+from .backend.postgis import PostGisBackend as DataBackend
+from .mapcss import MapCSS
 from twms import bbox, projections
-from render import RasterTile
+from .render import RasterTile
 import web
-import StringIO
+import io
 
 style = MapCSS(1, 26)  # zoom levels
 style.parse(open("styles/landuses.mapcss", "r").read())
@@ -98,7 +98,7 @@ def twms_main(req):
 
     res = RasterTile(width, height, z, db)
     res.update_surface(box, z, style)
-    image_content = StringIO.StringIO()
+    image_content = io.BytesIO()
 
     res.surface.write_to_png(image_content)
 

--- a/src/style.py
+++ b/src/style.py
@@ -18,9 +18,9 @@
 ### TODO: MapCSS loading and parsing
 
 
-from debug import debug
+from .debug import debug
 
-from mapcss.webcolors.webcolors import whatever_to_cairo as colorparser
+from .mapcss.webcolors.webcolors import whatever_to_cairo as colorparser
 
 
 class Styling():
@@ -61,7 +61,7 @@ class Styling():
 
         self.stylefile = stylefile
         self.useful_keys = set(["layer"])
-        for objtype in self.Selectors.values():  # getting useful keys
+        for objtype in list(self.Selectors.values()):  # getting useful keys
             for selector in objtype:
                 # debug(selector)
                 for tag in selector.tags:
@@ -147,11 +147,11 @@ class StyleSelector():
 
 if __name__ == "__main__":
     c = Styling()
-    print c.get_style("way", {"building": "yes"})
-    print c.get_style("way", {"highway": "residential"})
-    print c.get_style("way", {"highway": "road"})
-    print c.get_style("way", {"highway": "residential", "building": "yes"})
-    print c.get_style("way", {"highwadfgaay": "resifdgsdential", "builafgding": "yedfgs"})
-    print c.get_style("way", {"highwadfgaay": "resifdgsdential", "builafgding": "yedfgs"}, True)
-    print c.get_style("way", {"highway": "residential", "building": "yes"}, True)
-    print c.filter_tags({"highwadfgaay": "resifdgsdential", "builafgding": "yedfgs", "building": "residential"})
+    print(c.get_style("way", {"building": "yes"}))
+    print(c.get_style("way", {"highway": "residential"}))
+    print(c.get_style("way", {"highway": "road"}))
+    print(c.get_style("way", {"highway": "residential", "building": "yes"}))
+    print(c.get_style("way", {"highwadfgaay": "resifdgsdential", "builafgding": "yedfgs"}))
+    print(c.get_style("way", {"highwadfgaay": "resifdgsdential", "builafgding": "yedfgs"}, True))
+    print(c.get_style("way", {"highway": "residential", "building": "yes"}, True))
+    print(c.filter_tags({"highwadfgaay": "resifdgsdential", "builafgding": "yedfgs", "building": "residential"}))

--- a/src/test_stylesheet.py
+++ b/src/test_stylesheet.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from mapcss import MapCSS
-import mapcss.webcolors
-whatever_to_hex = mapcss.webcolors.webcolors.whatever_to_hex
+from .mapcss import MapCSS
+from .mapcss import webcolors
+import importlib
+whatever_to_hex = webcolors.webcolors.whatever_to_hex
 import sys
 
-reload(sys)
-sys.setdefaultencoding("utf-8")
+importlib.reload(sys)
+if hasattr(sys, "setdefaultencoding"):
+    sys.setdefaultencoding("utf-8")
 
 minzoom = 0
 maxzoom = 19
@@ -45,9 +47,9 @@ def compare_order(a, function, b):
                     mab = max(sb)
                     TOTAL_TESTS += 1
                     if (function == "over") and (mia <= mab):
-                        print "ORDER: z%s\t[%s %s %s %s %s]\t[%s, %s], " % (zoom, typ1, mia, function, typ2, mab, repr(a), repr(b))
-                        print style.get_style(typ1, a, zoom)
-                        print style.get_style(typ2, b, zoom)
+                        print("ORDER: z%s\t[%s %s %s %s %s]\t[%s, %s], " % (zoom, typ1, mia, function, typ2, mab, repr(a), repr(b)))
+                        print(style.get_style(typ1, a, zoom))
+                        print(style.get_style(typ2, b, zoom))
                         FAILED_TESTS += 1
 
 
@@ -64,7 +66,7 @@ def compare_line_lightness(a, function, b):
                     mab = max(sb)
                     TOTAL_TESTS += 1
                     if (function == "darker") and (mia >= mab):
-                        print "LIGHT: z%s\t[%s %s %s %s %s]\t[%s, %s], " % (zoom, typ1, mia, function, typ2, mab, repr(a), repr(b))
+                        print("LIGHT: z%s\t[%s %s %s %s %s]\t[%s, %s], " % (zoom, typ1, mia, function, typ2, mab, repr(a), repr(b)))
                         FAILED_TESTS += 1
 
 
@@ -78,7 +80,7 @@ def compare_visibility(a, function, b):
             if sa or sb:
                 TOTAL_TESTS += 1
                 if (function == "both") and not ((sa) and (sb)):
-                    print "VISIBILITY: z%s\t[%s %s %s %s %s]\t[%s, %s], " % (zoom, typ, bool(sa), function, typ, bool(sb), repr(a), repr(b))
+                    print("VISIBILITY: z%s\t[%s %s %s %s %s]\t[%s, %s], " % (zoom, typ, bool(sa), function, typ, bool(sb), repr(a), repr(b)))
                     FAILED_TESTS += 1
 
 
@@ -93,7 +95,7 @@ def has_stable_labels(a):
             if sa or sb:
                 TOTAL_TESTS += 1
                 if sb and not sa:
-                    print "LABELS: %s|z%s\t[%s]" % (typ, zoom, repr(a))
+                    print("LABELS: %s|z%s\t[%s]" % (typ, zoom, repr(a)))
                     FAILED_TESTS += 1
                 else:
                     prev[typ] = sa
@@ -112,7 +114,7 @@ def has_darker_casings(a):
                     light_color = get_color_lightness(x.get('color', 0.))
                     light_casing = get_color_lightness(x.get('casing-color', 0.))
                     if light_color != (light_casing + 2):
-                        print "CASINGS: %s|z%s\t[%s], base: %x (%s)  casing: %x (%s)" % (typ, zoom, repr(a), light_color, x.get('width'), light_casing, x.get('casing-width'))
+                        print("CASINGS: %s|z%s\t[%s], base: %x (%s)  casing: %x (%s)" % (typ, zoom, repr(a), light_color, x.get('width'), light_casing, x.get('casing-width')))
                         FAILED_TESTS += 1
 
 compare_order({'area:highway': 'primary'}, "over", {'highway': 'primary'})
@@ -199,6 +201,6 @@ has_darker_casings({'highway': 'unclassified'})
 
 
 if TOTAL_TESTS > 0:
-    print "Failed tests: %s (%s%%)" % (FAILED_TESTS, 100 * FAILED_TESTS / TOTAL_TESTS)
-print "Passed tests:", TOTAL_TESTS - FAILED_TESTS
-print "Total tests:", TOTAL_TESTS
+    print("Failed tests: %s (%s%%)" % (FAILED_TESTS, 100 * FAILED_TESTS / TOTAL_TESTS))
+print("Passed tests:", TOTAL_TESTS - FAILED_TESTS)
+print("Total tests:", TOTAL_TESTS)

--- a/src/texture_packer.py
+++ b/src/texture_packer.py
@@ -4,7 +4,7 @@ import pprint
 
 import Image
 import cairo
-import StringIO
+import io
 import rsvg
 
 from xml.dom import minidom
@@ -47,8 +47,8 @@ def open_icon_as_image(icon, multiplier = 1.0, max_height = None):
             [a.setAttribute("stroke", icon["color"]) for a in icon_dom.getElementsByTagName("g") if a.getAttribute("stroke")]
             [a.setAttribute("stroke", icon["color"]) for a in icon_dom.getElementsByTagName("rect") if a.getAttribute("stroke") not in ("none", "")]
 
-        tmpfile = StringIO.StringIO()
-        outfile = StringIO.StringIO()
+        tmpfile = io.BytesIO()
+        outfile = io.BytesIO()
         svg = rsvg.Handle(data=icon_dom.toxml())
         svgwidth = float(svg.get_property('width'))
         svgheight = float(svg.get_property('height'))
@@ -108,10 +108,10 @@ def pack_texture(icons=[], multiplier = 1.0, path = "", rasfilter = []):
             images[svg] = open_icon_as_image(icon, multiplier, max_height)
             area += images[svg].size[0] * images[svg].size[1]
         else:
-            print "bad icon!", icon
+            print("bad icon!", icon)
     width = 2 ** math.ceil(math.log(area ** 0.5, 2))
 
-    queue = images.keys()
+    queue = list(images.keys())
     queue.sort(key = lambda x: -images[x].size[1] * 10000 - images[x].size[0])
 
     for img in queue:
@@ -128,21 +128,21 @@ def pack_texture(icons=[], multiplier = 1.0, path = "", rasfilter = []):
     dx, dy = 0, 0
     icon_id = 0
     skin = open(os.path.join(path, 'basic.skn'), "w")
-    print >> skin, """<!DOCTYPE skin>
+    print("""<!DOCTYPE skin>
     <skin>
-    <page width="%s" height="%s" file="symbols.png">"""%(int(width), int(height))
+    <page width="%s" height="%s" file="symbols.png">"""%(int(width), int(height)), file=skin)
     for strip in strips:
         for img in strip["list"]:
             page.paste(images[img], (dx, dy))
             icon_id += 1
-            print >> skin,"""  <symbolStyle id="%s" name="%s">
+            print("""  <symbolStyle id="%s" name="%s">
     <resourceStyle x="%s" y="%s" width="%s" height="%s"/>
-    </symbolStyle>""" % (icon_id, img, dx, dy, images[img].size[0], images[img].size[1])
+    </symbolStyle>""" % (icon_id, img, dx, dy, images[img].size[0], images[img].size[1]), file=skin)
             dx += images[img].size[0]
         dy += strip["height"]
         dx = 0
     #pprint.pprint(strips)
 
-    print >>skin, """ </page>
-    </skin>"""
+    print(""" </page>
+    </skin>""", file=skin)
     page.save(os.path.join(path,"symbols.png"))

--- a/src/twms_fetcher.py
+++ b/src/twms_fetcher.py
@@ -14,19 +14,19 @@
 #   You should have received a copy of the GNU General Public License
 #   along with tWMS.  If not, see <http://www.gnu.org/licenses/>.
 
-import StringIO
+import io
 import Image
 import os
 import threading
-import thread
+import _thread
 
 from twms import projections
 import config
 
 # from vtiles_backend import QuadTileBackend as DataBackend
-from backend.postgis import PostGisBackend as DataBackend
-from mapcss import MapCSS
-from render import RasterTile
+from .backend.postgis import PostGisBackend as DataBackend
+from .mapcss import MapCSS
+from .render import RasterTile
 from tempfile import NamedTemporaryFile
 
 style = MapCSS(1, 19)
@@ -60,7 +60,7 @@ def kothic_fetcher(z, x, y, this_layer):
 
 def kothic_metatile(z, x, y, this_layer):
 
-    print z, x, y
+    print(z, x, y)
     global metatiles_in_progress
     if "max_zoom" in this_layer:
         if z >= this_layer["max_zoom"]:


### PR DESCRIPTION
## Summary
- apply `2to3` conversion for Python 3 compatibility
- replace deprecated `sys.setdefaultencoding` use with check
- fix `map(None, ...)` constructs and other syntax generated by `2to3`
- switch temporary image streams to `io.BytesIO`
- normalize RGB handling for color conversion
- clean up indentation issues
- adjust helper APIs that were incorrectly refactored

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 -m src.test_stylesheet src/styles/default.mapcss` (expected failures remain)
