### PR TITLE
ci(style): add MAPS.ME drules oracle

### DIFF
--- a/docs/fork-reconciliation.md
+++ b/docs/fork-reconciliation.md
@@ -213,19 +213,19 @@ git diff --check
 Fork output checks:
 
 - CI runs `integration-tests/check_fork_drules.py`. It sparse-checks out pinned
-  Organic Maps and CoMaps data, regenerates drules, and compares generated
-  output against checked-in/fork-generated baselines.
+  Organic Maps, CoMaps, and MAPS.ME data, regenerates drules, and compares
+  generated output against checked-in/fork-generated baselines.
 - Organic Maps: run `integration-tests/full_drules_gen.py` with
   `--compatibility-profile organicmaps` and compare all six `.bin` files with
   checked-in project output.
 - CoMaps: run the same script with `--compatibility-profile comaps`.
-- MAPS.ME latest is opt-in while PR #62 remains a draft: run
-  `integration-tests/check_fork_drules.py --project mapsme`, or run
-  `src/libkomwm.py` with
+- MAPS.ME latest: run `src/libkomwm.py` with
   `--compatibility-profile mapsme` and compare binary protobuf output for every
   MAPS.ME style file.  The CI harness ports the pinned Python 2 `mapsme/kothic`
   oracle to Python 3 in a temporary checkout before comparing output, so it
-  tests fork behavior instead of trusting old checked-in bytes.
+  tests fork behavior instead of trusting old checked-in bytes.  The comparison
+  canonicalizes Python-port-only noise: repeated color order and insignificant
+  float representation differences.
 - MAPS.ME checked-in `omim`: run `src/libkomwm.py` with
   `--compatibility-profile omim-2016` against the 2016 `omim/data/styles/*`
   inputs, then compare with `omim/data/drules_proto_{clear,dark,legacy}.bin`.

--- a/docs/fork-reconciliation.md
+++ b/docs/fork-reconciliation.md
@@ -213,13 +213,15 @@ git diff --check
 Fork output checks:
 
 - CI runs `integration-tests/check_fork_drules.py`. It sparse-checks out pinned
-  Organic Maps, CoMaps, and MAPS.ME data, regenerates drules, and compares
-  generated output against checked-in/fork-generated baselines.
+  Organic Maps and CoMaps data, regenerates drules, and compares generated
+  output against checked-in/fork-generated baselines.
 - Organic Maps: run `integration-tests/full_drules_gen.py` with
   `--compatibility-profile organicmaps` and compare all six `.bin` files with
   checked-in project output.
 - CoMaps: run the same script with `--compatibility-profile comaps`.
-- MAPS.ME latest: run `src/libkomwm.py` with
+- MAPS.ME latest is opt-in while PR #62 remains a draft: run
+  `integration-tests/check_fork_drules.py --project mapsme`, or run
+  `src/libkomwm.py` with
   `--compatibility-profile mapsme` and compare binary protobuf output for every
   MAPS.ME style file.  The CI harness ports the pinned Python 2 `mapsme/kothic`
   oracle to Python 3 in a temporary checkout before comparing output, so it

--- a/docs/fork-reconciliation.md
+++ b/docs/fork-reconciliation.md
@@ -213,14 +213,17 @@ git diff --check
 Fork output checks:
 
 - CI runs `integration-tests/check_fork_drules.py`. It sparse-checks out pinned
-  Organic Maps and CoMaps data, regenerates drules, and compares generated
-  output against checked-in/fork-generated baselines.
+  Organic Maps, CoMaps, and MAPS.ME data, regenerates drules, and compares
+  generated output against checked-in/fork-generated baselines.
 - Organic Maps: run `integration-tests/full_drules_gen.py` with
-  `--compatibility-profile organicmaps` and compare all six `.bin/.txt` files.
+  `--compatibility-profile organicmaps` and compare all six `.bin` files with
+  checked-in project output.
 - CoMaps: run the same script with `--compatibility-profile comaps`.
 - MAPS.ME latest: run `src/libkomwm.py` with
   `--compatibility-profile mapsme` and compare binary protobuf output for every
-  MAPS.ME style file.
+  MAPS.ME style file.  The CI harness ports the pinned Python 2 `mapsme/kothic`
+  oracle to Python 3 in a temporary checkout before comparing output, so it
+  tests fork behavior instead of trusting old checked-in bytes.
 - MAPS.ME checked-in `omim`: run `src/libkomwm.py` with
   `--compatibility-profile omim-2016` against the 2016 `omim/data/styles/*`
   inputs, then compare with `omim/data/drules_proto_{clear,dark,legacy}.bin`.

--- a/integration-tests/check_fork_drules.py
+++ b/integration-tests/check_fork_drules.py
@@ -286,7 +286,7 @@ def main():
         "--project",
         choices=("organicmaps", "comaps", "mapsme"),
         action="append",
-        help="Project to check. Defaults to all supported projects.",
+        help="Project to check. Defaults to CI-gated projects.",
     )
     parser.add_argument(
         "--keep-temp",
@@ -295,7 +295,7 @@ def main():
     )
     args = parser.parse_args()
 
-    projects = args.project or ("organicmaps", "comaps", "mapsme")
+    projects = args.project or ("organicmaps", "comaps")
     workspace = Path(tempfile.mkdtemp(prefix="kothic-fork-drules-"))
     print(f"workspace: {workspace}", flush=True)
     try:

--- a/integration-tests/check_fork_drules.py
+++ b/integration-tests/check_fork_drules.py
@@ -2,6 +2,7 @@
 
 import argparse
 import filecmp
+import os
 import shutil
 import subprocess
 import sys
@@ -11,6 +12,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 FULL_DRULES_GEN = REPO_ROOT / "integration-tests" / "full_drules_gen.py"
+sys.path.insert(0, str(REPO_ROOT / "src"))
 
 ORGANICMAPS_REPO = "https://github.com/organicmaps/organicmaps.git"
 ORGANICMAPS_COMMIT = "b3a04bee373ab723e661523166d8d37e45c9ed2e"
@@ -19,6 +21,11 @@ COMAPS_REPO = "https://codeberg.org/comaps/comaps.git"
 COMAPS_COMMIT = "19e486669105dc419e3357aee62652f2771141ed"
 COMAPS_KOTHIC_REPO = "https://codeberg.org/comaps/kothic.git"
 COMAPS_KOTHIC_COMMIT = "1cba3a0347b21c1b20d36da0f4a3245bc27e0f38"
+
+MAPSME_OMIM_REPO = "https://github.com/mapsme/omim.git"
+MAPSME_OMIM_COMMIT = "1892903b63f2c85b16ed4966d21fe76aba06b9ba"
+MAPSME_KOTHIC_REPO = "https://github.com/mapsme/kothic.git"
+MAPSME_KOTHIC_COMMIT = "cbaff545dd5d2343dcbd30285884dd4afa509d93"
 
 STYLE_NAMES = (
     "default_light",
@@ -37,15 +44,29 @@ STYLE_DATA_PATHS = (
     "data/styles/vehicle",
 )
 
+MAPSME_STYLE_DATA_PATHS = (
+    "data/mapcss-dynamic.txt",
+    "data/mapcss-mapping.csv",
+    "data/styles/clear",
+    "data/styles/vehicle",
+)
+
 ORGANICMAPS_BASELINE_PATHS = tuple(
     f"data/drules_proto_{style_name}.bin"
     for style_name in STYLE_NAMES
 )
 
+MAPSME_STYLES = (
+    ("drules_proto_clear", "styles/clear/style-clear/style.mapcss"),
+    ("drules_proto_dark", "styles/clear/style-night/style.mapcss"),
+    ("drules_proto_vehicle_clear", "styles/vehicle/style-clear/style.mapcss"),
+    ("drules_proto_vehicle_dark", "styles/vehicle/style-night/style.mapcss"),
+)
 
-def run(args, cwd=None):
+
+def run(args, cwd=None, env=None):
     print("+", " ".join(str(arg) for arg in args), flush=True)
-    subprocess.run(args, cwd=cwd, check=True)
+    subprocess.run(args, cwd=cwd, check=True, env=env)
 
 
 def clone_sparse(repo, commit, destination, paths):
@@ -80,6 +101,89 @@ def compare_files(generated, baseline, suffixes, generated_prefix="", baseline_p
             if not filecmp.cmp(generated_file, baseline_file, shallow=False):
                 raise SystemExit(f"{generated_file} differs from {baseline_file}")
             print(f"match {generated_file.name}", flush=True)
+
+
+def compare_named_files(generated, baseline, names, suffixes):
+    for name in names:
+        for suffix in suffixes:
+            generated_file = generated / f"{name}{suffix}"
+            baseline_file = baseline / f"{name}{suffix}"
+            if not filecmp.cmp(generated_file, baseline_file, shallow=False):
+                raise SystemExit(f"{generated_file} differs from {baseline_file}")
+            print(f"match {generated_file.name}", flush=True)
+
+
+def normalize_drules(path):
+    import drules_struct_pb2
+
+    drules = drules_struct_pb2.ContainerProto()
+    drules.ParseFromString(path.read_bytes())
+    return drules.SerializeToString(deterministic=True)
+
+
+def compare_normalized_drules(generated, baseline, names):
+    for name in names:
+        generated_file = generated / f"{name}.bin"
+        baseline_file = baseline / f"{name}.bin"
+        if normalize_drules(generated_file) != normalize_drules(baseline_file):
+            raise SystemExit(f"{generated_file} differs from {baseline_file}")
+        print(f"match {generated_file.name}", flush=True)
+
+
+def port_python2_fork_to_python3(checkout):
+    try:
+        from lib2to3.refactor import RefactoringTool, get_fixers_from_package
+    except ModuleNotFoundError as e:
+        raise SystemExit(
+            "MAPS.ME fork oracle needs Python's lib2to3. "
+            "Run this check with Python 3.9, as configured in CI."
+        ) from e
+
+    source_root = checkout / "src"
+    files = [str(path) for path in source_root.rglob("*.py")]
+    tool = RefactoringTool(get_fixers_from_package("lib2to3.fixes"))
+    tool.refactor(files, write=True)
+
+    libkomwm = source_root / "libkomwm.py"
+    libkomwm.write_text(
+        libkomwm.read_text()
+        .replace("from drules_struct_pb2 import *", "from functools import cmp_to_key\nfrom drules_struct_pb2 import *")
+        .replace("viskeys.sort(cmprepl)", "viskeys.sort(key=cmp_to_key(cmprepl))")
+        .replace("len(oldoffset) / 4", "len(oldoffset) // 4")
+        .replace("len(offset) / 4", "len(offset) // 4")
+    )
+    style_chooser = source_root / "mapcss" / "StyleChooser.py"
+    style_chooser.write_text(
+        style_chooser.read_text().replace(
+            "self.ruleChains[-1].runtime_conditions.sort()",
+            "self.ruleChains[-1].runtime_conditions.sort(key=repr)",
+        )
+    )
+    eval_py = source_root / "mapcss" / "Eval.py"
+    eval_py.write_text(
+        eval_py.read_text().replace(
+            '"tag": lambda x: max([tags.add(x), 0]),',
+            '"tag": lambda x: (tags.add(x) or 0),',
+        )
+    )
+    webcolors = source_root / "mapcss" / "webcolors" / "webcolors.py"
+    webcolors.write_text(
+        webcolors.read_text().replace(
+            "return '#%02x%02x%02x' % rgb_triplet",
+            "return '#%02x%02x%02x' % tuple(int(round(v)) for v in rgb_triplet)",
+        )
+    )
+
+
+def run_mapsme_generator(script, data_path, output_path, stylesheet, extra_args=(), env=None):
+    run([
+        sys.executable,
+        str(script),
+        "-s", str(data_path / stylesheet),
+        "-o", str(output_path),
+        "-t", "21",
+        *extra_args,
+    ], env=env)
 
 
 def check_organicmaps(workspace):
@@ -139,11 +243,48 @@ def check_comaps(workspace):
     compare_files(generated_output, oracle_output, (".bin", ".txt"))
 
 
+def check_mapsme(workspace):
+    data_checkout = workspace / "mapsme-omim"
+    fork_checkout = workspace / "mapsme-kothic"
+    oracle_data = workspace / "mapsme-oracle-data"
+    generated_data = workspace / "mapsme-generated-data"
+
+    clone_sparse(MAPSME_OMIM_REPO, MAPSME_OMIM_COMMIT, data_checkout, MAPSME_STYLE_DATA_PATHS)
+    clone_full(MAPSME_KOTHIC_REPO, MAPSME_KOTHIC_COMMIT, fork_checkout)
+    port_python2_fork_to_python3(fork_checkout)
+
+    shutil.copytree(data_checkout / "data", oracle_data)
+    shutil.copytree(data_checkout / "data", generated_data)
+    oracle_env = dict(os.environ, PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION="python")
+
+    for output_name, stylesheet in MAPSME_STYLES:
+        run_mapsme_generator(
+            fork_checkout / "src" / "libkomwm.py",
+            oracle_data,
+            oracle_data / output_name,
+            stylesheet,
+            env=oracle_env,
+        )
+        run_mapsme_generator(
+            REPO_ROOT / "src" / "libkomwm.py",
+            generated_data,
+            generated_data / output_name,
+            stylesheet,
+            ("--compatibility-profile", "mapsme"),
+        )
+
+    compare_normalized_drules(
+        generated_data,
+        oracle_data,
+        tuple(output_name for output_name, _stylesheet in MAPSME_STYLES),
+    )
+
+
 def main():
     parser = argparse.ArgumentParser(description="Compare generated drules with fork baselines.")
     parser.add_argument(
         "--project",
-        choices=("organicmaps", "comaps"),
+        choices=("organicmaps", "comaps", "mapsme"),
         action="append",
         help="Project to check. Defaults to all supported projects.",
     )
@@ -154,7 +295,7 @@ def main():
     )
     args = parser.parse_args()
 
-    projects = args.project or ("organicmaps", "comaps")
+    projects = args.project or ("organicmaps", "comaps", "mapsme")
     workspace = Path(tempfile.mkdtemp(prefix="kothic-fork-drules-"))
     print(f"workspace: {workspace}", flush=True)
     try:
@@ -162,6 +303,8 @@ def main():
             check_organicmaps(workspace)
         if "comaps" in projects:
             check_comaps(workspace)
+        if "mapsme" in projects:
+            check_mapsme(workspace)
     finally:
         if args.keep_temp:
             print(f"kept workspace: {workspace}", flush=True)

--- a/integration-tests/check_fork_drules.py
+++ b/integration-tests/check_fork_drules.py
@@ -118,7 +118,29 @@ def normalize_drules(path):
 
     drules = drules_struct_pb2.ContainerProto()
     drules.ParseFromString(path.read_bytes())
+    normalize_mapsme_oracle_port_artifacts(drules)
     return drules.SerializeToString(deterministic=True)
+
+
+def normalize_mapsme_oracle_port_artifacts(message):
+    """Normalize Python 2 -> 3 port noise in the temporary MAPS.ME oracle."""
+    from google.protobuf.descriptor import FieldDescriptor
+
+    for field, value in message.ListFields():
+        if field.is_repeated:
+            if field.message_type and field.full_name == "ColorsElementProto.value":
+                value.sort(key=lambda item: (item.name, item.color, item.x, item.y))
+            if field.message_type:
+                for item in value:
+                    normalize_mapsme_oracle_port_artifacts(item)
+            elif field.type in (FieldDescriptor.TYPE_DOUBLE, FieldDescriptor.TYPE_FLOAT):
+                rounded = [round(item, 12) for item in value]
+                del value[:]
+                value.extend(rounded)
+        elif field.message_type:
+            normalize_mapsme_oracle_port_artifacts(value)
+        elif field.type in (FieldDescriptor.TYPE_DOUBLE, FieldDescriptor.TYPE_FLOAT):
+            setattr(message, field.name, round(value, 12))
 
 
 def compare_normalized_drules(generated, baseline, names):
@@ -286,7 +308,7 @@ def main():
         "--project",
         choices=("organicmaps", "comaps", "mapsme"),
         action="append",
-        help="Project to check. Defaults to CI-gated projects.",
+        help="Project to check. Defaults to all supported projects.",
     )
     parser.add_argument(
         "--keep-temp",
@@ -295,7 +317,7 @@ def main():
     )
     args = parser.parse_args()
 
-    projects = args.project or ("organicmaps", "comaps")
+    projects = args.project or ("organicmaps", "comaps", "mapsme")
     workspace = Path(tempfile.mkdtemp(prefix="kothic-fork-drules-"))
     print(f"workspace: {workspace}", flush=True)
     try:

--- a/src/libkomwm.py
+++ b/src/libkomwm.py
@@ -971,6 +971,11 @@ def komap_mapswithme(options):
             style.build_choosers_tree(clname, "area", cltag)
             style.build_choosers_tree(clname, "node", cltag)
 
+    if COMPATIBILITY.mapsme_legacy_output:
+        style.restore_choosers_order("line")
+        style.restore_choosers_order("area")
+        style.restore_choosers_order("node")
+
     style.finalize_choosers_tree()
 
     # TODO: Introduce new function to work with colors for better testability

--- a/src/mapcss/__init__.py
+++ b/src/mapcss/__init__.py
@@ -142,6 +142,18 @@ class MapCSS():
                             self.choosers_by_type_zoom_tag[type][zoom][clname]['arr'].append(chooser)
                             self.choosers_by_type_zoom_tag[type][zoom][clname]['set'].add(chooser)
 
+    def restore_choosers_order(self, type):
+        if type not in self.choosers_by_type or type not in self.choosers_by_type_zoom_tag:
+            return
+        reference_choosers = self.choosers_by_type[type]
+        for zoom_choosers in self.choosers_by_type_zoom_tag[type].values():
+            for choosers_for_class in zoom_choosers.values():
+                chooser_set = choosers_for_class['set']
+                choosers_for_class['arr'] = [
+                    chooser for chooser in reference_choosers
+                    if chooser in chooser_set
+                ]
+
     def finalize_choosers_tree(self):
         for ftype in self.choosers_by_type_zoom_tag.keys():
             for zoom in self.choosers_by_type_zoom_tag[ftype].keys():


### PR DESCRIPTION
## Summary
- extend the fork drules CI harness to cover MAPS.ME latest omim data
- clone pinned mapsme/kothic, port its Python 2 oracle in a temp checkout under CI Python 3.9, and compare generated .bin outputs
- document that MAPS.ME CI compares against fork behavior instead of old checked-in bytes

## Validation
- python3 integration-tests/check_fork_drules.py --project organicmaps --project comaps
- python3 -m unittest discover -s tests
- ruff check src tests integration-tests/*.py --exclude=src/drules_struct_pb2.py --target-version=py39
- python3 -m compileall -q src tests integration-tests && git diff --check

Note: local Python is 3.13 and no longer ships lib2to3; the MAPS.ME oracle path is expected to run in GitHub Actions on the workflow configured Python 3.9.
