### PR TITLE
feat: support optional PostGIS datasource parameters

### DIFF
--- a/src/komap.conf
+++ b/src/komap.conf
@@ -4,6 +4,9 @@ db_proj = +init=epsg:3857
 table_prefix = planet_osm_
 db_user = gis
 db_name = gis
+db_password =
+db_host =
+db_port =
 db_srid = 900913
 icons_path = /home/gis/mapnik/kosmo/icons/
 world_bnd_path = /home/gis/mapnik/world_boundaries/

--- a/src/komap.py
+++ b/src/komap.py
@@ -144,6 +144,13 @@ def main(argv=None):
         libkomapnik.table_prefix = config.get("mapnik", "table_prefix")
         libkomapnik.db_user = config.get("mapnik", "db_user")
         libkomapnik.db_name = config.get("mapnik", "db_name")
+        libkomapnik.db_password = config.get(
+            "mapnik",
+            "db_password",
+            fallback=config.get("mapnik", "db_passwd", fallback=""),
+        )
+        libkomapnik.db_host = config.get("mapnik", "db_host", fallback="")
+        libkomapnik.db_port = config.get("mapnik", "db_port", fallback="")
         libkomapnik.db_srid = config.get("mapnik", "db_srid")
         libkomapnik.icons_path = config.get("mapnik", "icons_path")
         libkomapnik.world_bnd_path = config.get("mapnik", "world_bnd_path")

--- a/src/libkomapnik.py
+++ b/src/libkomapnik.py
@@ -18,6 +18,7 @@
 
 import os
 import math
+from xml.sax.saxutils import escape
 
 from .mapcss.webcolors.webcolors import whatever_to_hex as nicecolor
 
@@ -27,6 +28,9 @@ db_proj = ""
 table_prefix = ""
 db_user = ""
 db_name = ""
+db_password = ""
+db_host = ""
+db_port = ""
 db_srid = ""
 icons_path = ""
 world_bnd_path = ""
@@ -49,6 +53,23 @@ def get_id(i=0):
     global last_id
     last_id += i
     return last_id
+
+
+def xml_postgis_connection_parameters():
+    params = []
+    for name, value in (
+        ("password", db_password),
+        ("host", db_host),
+        ("port", db_port),
+    ):
+        if value:
+            params.append(
+                '            <Parameter name="%s">%s</Parameter>' % (
+                    name,
+                    escape(str(value)),
+                )
+            )
+    return "\n".join(params)
 
 
 def zoom_to_scaledenom(z1, z2=False):
@@ -354,13 +375,31 @@ def xml_layer(type="postgis", geom="point", interesting_tags="*", sql="true", zo
             <Parameter name="st_prefix">true</Parameter>
             <Parameter name="user">%s</Parameter>
             <Parameter name="dbname">%s</Parameter>
+%s
             <Parameter name="srid">%s</Parameter>
             <Parameter name="geometry_field">way</Parameter>
             <Parameter name="geometry_table">%s%s</Parameter>
             <Parameter name="estimate_extent">false</Parameter>
             <Parameter name="extent">-20037508.342789244, -20037508.342780735, 20037508.342789244, 20037508.342780709</Parameter>
           </Datasource>
-        </Layer>""" % (layer_id, db_proj, subs, zoom, interesting_tags, waystring, table_prefix, geom, sql, intersection_SQL, db_user, db_name, db_srid,  table_prefix, geom)
+        </Layer>""" % (
+            layer_id,
+            db_proj,
+            subs,
+            zoom,
+            interesting_tags,
+            waystring,
+            table_prefix,
+            geom,
+            sql,
+            intersection_SQL,
+            db_user,
+            db_name,
+            xml_postgis_connection_parameters(),
+            db_srid,
+            table_prefix,
+            geom,
+        )
     elif type == "postgis-process":
         return """
         <Layer name="l%s" status="on" srs="%s">
@@ -376,13 +415,27 @@ def xml_layer(type="postgis", geom="point", interesting_tags="*", sql="true", zo
             <Parameter name="st_prefix">true</Parameter>
             <Parameter name="user">%s</Parameter>
             <Parameter name="dbname">%s</Parameter>
+%s
             <Parameter name="srid">%s</Parameter>
             <Parameter name="geometry_field">way</Parameter>
             <Parameter name="geometry_table">%s%s</Parameter>
             <Parameter name="estimate_extent">false</Parameter>
             <Parameter name="extent">-20037508.342789244, -20037508.342780735, 20037508.342789244, 20037508.342780709</Parameter>
           </Datasource>
-        </Layer>""" % (layer_id, db_proj, subs, zoom, sql, intersection_SQL, db_user, db_name, db_srid,  table_prefix, geom)
+        </Layer>""" % (
+            layer_id,
+            db_proj,
+            subs,
+            zoom,
+            sql,
+            intersection_SQL,
+            db_user,
+            db_name,
+            xml_postgis_connection_parameters(),
+            db_srid,
+            table_prefix,
+            geom,
+        )
     elif type == "coast":
         if zoom < 9:
             return """

--- a/tests/testKothicMvtHelpers.py
+++ b/tests/testKothicMvtHelpers.py
@@ -7,6 +7,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from src import libkomb
+from src import libkomapnik
 from src import mvt_sql
 from src.mapcss import Condition
 
@@ -15,6 +16,9 @@ class KothicMvtHelpersTest(unittest.TestCase):
     def tearDown(self):
         mvt_sql.mapped_cols.clear()
         mvt_sql.osm2pgsql_avail_keys.clear()
+        libkomapnik.db_password = ""
+        libkomapnik.db_host = ""
+        libkomapnik.db_port = ""
 
     def test_mapbox_expression_collapses_repeated_zoom_values(self):
         self.assertEqual(
@@ -58,6 +62,30 @@ class KothicMvtHelpersTest(unittest.TestCase):
             mvt_sql.pixel_size_at_zoom(2),
             mvt_sql.pixel_size_at_zoom(1) / 2
         )
+
+    def test_postgis_connection_parameters_are_optional(self):
+        layer = libkomapnik.xml_layer("postgis", "point", ["name"], "true", zoom=10)
+
+        self.assertNotIn('<Parameter name="password">', layer)
+        self.assertNotIn('<Parameter name="host">', layer)
+        self.assertNotIn('<Parameter name="port">', layer)
+
+    def test_postgis_connection_parameters_are_rendered_when_configured(self):
+        libkomapnik.db_password = "secret&safe"
+        libkomapnik.db_host = "db.example.test"
+        libkomapnik.db_port = "5433"
+
+        layer = libkomapnik.xml_layer(
+            "postgis-process",
+            "polygon",
+            ["name"],
+            "select way, name from planet_osm_polygon",
+            zoom=10
+        )
+
+        self.assertIn('<Parameter name="password">secret&amp;safe</Parameter>', layer)
+        self.assertIn('<Parameter name="host">db.example.test</Parameter>', layer)
+        self.assertIn('<Parameter name="port">5433</Parameter>', layer)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Replacement for #13 with the same underlying goal, but updated for current main.

Adds optional PostGIS datasource settings for the Mapnik renderer:

- db_password
- db_host
- db_port

Empty values stay omitted from generated Mapnik XML, so existing local/default PostgreSQL setups keep their current behavior. The old db_passwd key is accepted as a compatibility fallback, but the sample config uses db_password and does not include a fake password.

## Why not merge #13 directly

#13 is from 2013 and adds db_passwd = XXXXXX to the sample config. This PR keeps the useful host/port/password support, but makes the parameters optional and adds regression coverage for the generated datasource XML.

## Verification

- python3 -m unittest discover -s tests
- python3 -m compileall -q src tests integration-tests
- git diff --check
- manual XML smoke confirmed password values are escaped and host/port/password parameters are only rendered when configured.