### PR TITLE
feat: add Georgian name romanization

### DIFF
--- a/src/mvt_sql.py
+++ b/src/mvt_sql.py
@@ -11,6 +11,45 @@ mapped_cols = {}
 osm2pgsql_avail_keys = {}
 
 
+def sql_literal(value):
+    return "'%s'" % value.replace("'", "''")
+
+
+def translate_replace_sql(source, replacements, translate_from="", translate_to=""):
+    if translate_from:
+        sql = "translate(%s,%s,%s)" % (
+            source,
+            sql_literal(translate_from),
+            sql_literal(translate_to),
+        )
+    else:
+        sql = source
+
+    for old, new in replacements:
+        sql = "replace(%s,%s,%s)" % (sql, sql_literal(old), sql_literal(new))
+
+    return sql
+
+
+def georgian_romanization_sql(source):
+    return translate_replace_sql(
+        source,
+        [
+            ("ძ", "dz"),
+            ("წ", "ts"),
+            ("ჭ", "ch"),
+            ("შ", "sh"),
+            ("ჩ", "ch"),
+            ("ც", "ts"),
+            ("ღ", "gh"),
+            ("ხ", "kh"),
+            ("ჟ", "zh"),
+        ],
+        "აბგდევზთიკლმნოპრსტუფქყჯჰ",
+        "abgdevztiklmnoprstupkqjh",
+    )
+
+
 def escape_sql_column(name, type, asname=False):
     if name in mapped_cols:
         if asname:
@@ -89,8 +128,8 @@ def get_sql_hints(choosers, obj, zoom):
     )
 
     hints = set()
+    tags = set()
     for chooser in choosers:
-        tags = set()
         if not needed.isdisjoint(set(chooser.styles[0].keys())):
             for rule in chooser.ruleChains:
                 if obj:
@@ -152,6 +191,7 @@ def get_vectors(minzoom, maxzoom, x, y, style, vec, extent, locales):
         ] = """coalesce(
         tags->'name:en',
         tags->'int_name',
+        %s,
         replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace
         (replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace
         (replace(replace
@@ -165,7 +205,7 @@ def get_vectors(minzoom, maxzoom, x, y, style, vec, extent, locales):
         'lЁ', 'lIo'), 'lЮ', 'lIu'), 'lЯ', 'lIa'), 'lе', 'lie'), 'lё', 'lio'), 'lю', 'liu'), 'lя', 'lia'), 'mЕ', 'mIe'), 'mЁ', 'mIo'), 'mЮ', 'mIu'), 'mЯ', 'mIa'), 'mе', 'mie'), 'mё', 'mio'), 'mю', 'miu'), 'mя', 'mia'), 'nЕ', 'nIe'), 'nЁ', 'nIo'), 'nЮ', 'nIu'), 'nЯ', 'nIa'), 'nе', 'nie'), 'nё', 'nio'), 'nю', 'niu'), 'nя', 'nia'), 'pЕ', 'pIe'), 'pЁ', 'pIo'), 'pЮ', 'pIu'), 'pЯ', 'pIa'), 'pе', 'pie'), 'pё', 'pio'), 'pю', 'piu'), 'pя', 'pia'), 'rЕ', 'rIe'), 'rЁ', 'rIo'), 'rЮ', 'rIu'), 'rЯ', 'rIa'), 'rе', 'rie'), 'rё', 'rio'), 'rю', 'riu'), 'rя', 'ria'), 'sЕ', 'sIe'), 'sЁ',
         'sIo'), 'sЮ', 'sIu'), 'sЯ', 'sIa'), 'sе', 'sie'), 'sё', 'sio'), 'sю', 'siu'), 'sя', 'sia'), 'tЕ', 'tIe'), 'tЁ', 'tIo'), 'tЮ', 'tIu'), 'tЯ', 'tIa'), 'tе', 'tie'), 'tё', 'tio'), 'tю', 'tiu'), 'tя', 'tia'), 'ŭЕ', 'ŭIe'), 'ŭЁ', 'ŭIo'), 'ŭЮ', 'ŭIu'), 'ŭЯ', 'ŭIa'), 'ŭе', 'ŭie'), 'ŭё', 'ŭio'), 'ŭю', 'ŭiu'), 'ŭя', 'ŭia'), 'fЕ', 'fIe'), 'fЁ', 'fIo'), 'fЮ', 'fIu'), 'fЯ', 'fIa'), 'fе', 'fie'), 'fё', 'fio'), 'fю', 'fiu'), 'fя', 'fia'), 'сЕ', 'сIe'), 'сЁ', 'сIo'), 'сЮ', 'сIu'), 'сЯ', 'сIa'), 'се', 'сie'), 'сё', 'сio'), 'сю', 'сiu'), 'ся', 'сia'), 'čЕ', 'čIe'), 'čЁ', 'čIo'), 'čЮ', 'čIu'), 'čЯ', 'čIa'), 'čе', 'čie'), 'čё',
         'čio'), 'čю', 'čiu'), 'čя', 'čia'), 'šЕ', 'šIe'), 'šЁ', 'šIo'), 'šЮ', 'šIu'), 'šЯ', 'šIa'), 'šе', 'šie'), 'šё', 'šio'), 'šю', 'šiu'), 'šя', 'šia'), 'Е', 'Je'), 'Ё', 'Jo'), 'Ю', 'Ju'), 'Я', 'Ja'), 'е', 'je'), 'ё', 'jo'), 'ю', 'ju'), 'я', 'ja'), 'Ь', E'\\u0301'), 'ь', E'\\u0301'),'’', ''),
-        replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(translate(tags->'name:ru','абвгдезиклмнопрстуфьАБВГДЕЗИКЛМНОПРСТУФЬ','abvgdeziklmnoprstuf’ABVGDEZIKLMNOPRSTUF’'),'х','kh'),'Х','Kh'),'ц','ts'),'Ц','Ts'),'ч','ch'),'Ч','Ch'),'ш','sh'),'Ш','Sh'),'щ','shch'),'Щ','Shch'),'ъ','”'),'Ъ','”'),'ё','yo'),'Ё','Yo'),'ы','y'),'Ы','Y'),'э','·e'),'Э','E'),'ю','yu'),'Ю','Yu'),'й','y'),'Й','Y'),'я','ya'),'Я','Ya'),'ж','zh'),'Ж','Zh'))"""
+        replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(translate(tags->'name:ru','абвгдезиклмнопрстуфьАБВГДЕЗИКЛМНОПРСТУФЬ','abvgdeziklmnoprstuf’ABVGDEZIKLMNOPRSTUF’'),'х','kh'),'Х','Kh'),'ц','ts'),'Ц','Ts'),'ч','ch'),'Ч','Ch'),'ш','sh'),'Ш','Sh'),'щ','shch'),'Щ','Shch'),'ъ','”'),'Ъ','”'),'ё','yo'),'Ё','Yo'),'ы','y'),'Ы','Y'),'э','·e'),'Э','E'),'ю','yu'),'Ю','Yu'),'й','y'),'Й','Y'),'я','ya'),'Я','Ya'),'ж','zh'),'Ж','Zh'))""" % georgian_romanization_sql("tags->'name:ka'")
 
     adp = " OR ".join(adp)
     if adp:

--- a/tests/testKothicMvtHelpers.py
+++ b/tests/testKothicMvtHelpers.py
@@ -63,6 +63,39 @@ class KothicMvtHelpersTest(unittest.TestCase):
             mvt_sql.pixel_size_at_zoom(1) / 2
         )
 
+    def test_georgian_romanization_sql_uses_readable_mapping(self):
+        sql = mvt_sql.georgian_romanization_sql("tags->'name:ka'")
+
+        self.assertIn(
+            "translate(tags->'name:ka','აბგდევზთიკლმნოპრსტუფქყჯჰ','abgdevztiklmnoprstupkqjh')",
+            sql
+        )
+        self.assertIn("'ძ','dz'", sql)
+        self.assertIn("'ხ','kh'", sql)
+        self.assertIn("'ჟ','zh'", sql)
+        self.assertNotIn("ts’", sql)
+
+    def test_english_name_fallback_includes_georgian_romanization(self):
+        class Style:
+            choosers = []
+
+            def get_all_tags(self, _obj):
+                return {"name"}
+
+            def get_interesting_tags(self, _obj, _zoom):
+                return {"name"}
+
+        mvt_sql.get_vectors(0, 0, 0, 0, Style(), "point", 4096, ["en"])
+
+        name_en_sql = mvt_sql.mapped_cols["name:en"]
+
+        self.assertIn("tags->'name:ka'", name_en_sql)
+        self.assertIn("'ხ','kh'", name_en_sql)
+        self.assertLess(
+            name_en_sql.index("tags->'name:ka'"),
+            name_en_sql.index("tags->'name:be'")
+        )
+
     def test_postgis_connection_parameters_are_optional(self):
         layer = libkomapnik.xml_layer("postgis", "point", ["name"], "true", zoom=10)
 


### PR DESCRIPTION
### Summary

- add Georgian `name:ka` romanization as a fallback for generated `name:en`
  SQL
- keep the mapping readable in `georgian_romanization_sql(...)` instead of
  inlining another long nested `replace(...)` chain by hand
- cover the helper and the real `get_vectors(... locales=["en"])` fallback path
- fix `get_sql_hints(...)` for styles with no choosers, which the new focused
  test exercises

Supersedes #59 with credit to @ekatyshev for the original Georgian romanization
mapping.

### Verification

```sh
python3 -m unittest tests.testKothicMvtHelpers
python3 -m unittest discover -s tests
python3 -m compileall -q src tests integration-tests
ruff check src tests integration-tests/*.py --exclude=src/drules_struct_pb2.py --target-version=py39
git diff --check
```

### Notes

The old PR is dirty against `main` and appends another hard-to-review SQL
literal. This replacement keeps the behavior small and testable while preserving
the existing Belarusian and Russian fallback order.
