### PR TITLE
test: add MapCSS parse benchmark

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,13 +17,5 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install ruff
-      - name: Check Python 3 runtime blockers
-        run: ruff check --select=E9,F63,F7,F82 --exclude=src/drules_struct_pb2.py --output-format=github --target-version=py39
-      - name: Lint maintained Python surfaces
-        run: ruff check src tests integration-tests/*.py --exclude=src/drules_struct_pb2.py --output-format=github --target-version=py39
-      - name: Compile Python sources
-        run: python -m compileall -q src tests integration-tests
-      - name: Run unit-tests
-        run: python -m unittest discover -s tests
-      - name: Check fork drules compatibility
-        run: python integration-tests/check_fork_drules.py
+      - name: Run local CI check suite
+        run: python integration-tests/run_ci_checks.py

--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ python3 -m unittest discover -s tests
 this will search for all `test*.py` files within `tests` directory
 and execute tests from those files.
 
+Before pushing changes, run the same checks as GitHub Actions:
+
+```bash
+python3 integration-tests/run_ci_checks.py
+```
+
+This includes fork drules compatibility.  The MAPS.ME oracle still needs
+Python's `lib2to3`, so use the same Python 3.9 runtime as CI for a full local
+run.
+
 ## Running integration tests
 
 File `integration-tests/full_drules_gen.py` is intended to generate drules

--- a/docs/fork-reconciliation.md
+++ b/docs/fork-reconciliation.md
@@ -178,6 +178,12 @@ Important behavior kept in `--compatibility-profile mapsme`:
 - old protobuf serialization quirks such as empty `dashdot {}` for casing
   lines.
 
+The comparison harness intentionally does **not** preserve the old fork parser
+bug for colon-bearing declaration values like `text:"addr:housename"`.  Modern
+Kothic parses that as `text: addr:housename`; the MAPS.ME oracle input is
+normalized to the same semantic style before comparing the remaining legacy
+behavior.
+
 Verified output: all found MAPS.ME style `.bin` files matched the latest
 `mapsme/kothic` fork oracle:
 

--- a/integration-tests/check_fork_drules.py
+++ b/integration-tests/check_fork_drules.py
@@ -208,6 +208,21 @@ def run_mapsme_generator(script, data_path, output_path, stylesheet, extra_args=
     ], env=env)
 
 
+def normalize_mapsme_oracle_input(data_path):
+    """Keep MAPS.ME oracle comparison focused on intentional legacy behavior.
+
+    The pinned MAPS.ME fork parser mis-parses declarations like
+    `text:"addr:housename"` as a key named `text:"addr`.  Modern Kothic should
+    parse that as the `text` property with a colon-bearing value.  Normalize the
+    temporary oracle input so the old fork produces the same semantic style
+    before comparing all other MAPS.ME compatibility details.
+    """
+    for stylesheet in data_path.glob("styles/*/*/*.mapcss"):
+        stylesheet.write_text(
+            stylesheet.read_text().replace('text:"addr:housename"', 'text: "addr:housename"')
+        )
+
+
 def check_organicmaps(workspace):
     checkout = workspace / "organicmaps"
     output = workspace / "organicmaps-generated"
@@ -277,6 +292,7 @@ def check_mapsme(workspace):
 
     shutil.copytree(data_checkout / "data", oracle_data)
     shutil.copytree(data_checkout / "data", generated_data)
+    normalize_mapsme_oracle_input(oracle_data)
     oracle_env = dict(os.environ, PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION="python")
 
     for output_name, stylesheet in MAPSME_STYLES:

--- a/integration-tests/run_ci_checks.py
+++ b/integration-tests/run_ci_checks.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def integration_python_files():
+    return sorted(str(path.relative_to(REPO_ROOT)) for path in (REPO_ROOT / "integration-tests").glob("*.py"))
+
+
+CHECKS = (
+    (
+        "Check Python 3 runtime blockers",
+        [
+            sys.executable,
+            "-m",
+            "ruff",
+            "check",
+            "--select=E9,F63,F7,F82",
+            "--exclude=src/drules_struct_pb2.py",
+            "--target-version=py39",
+        ],
+    ),
+    (
+        "Lint maintained Python surfaces",
+        [
+            sys.executable,
+            "-m",
+            "ruff",
+            "check",
+            "src",
+            "tests",
+            *integration_python_files(),
+            "--exclude=src/drules_struct_pb2.py",
+            "--target-version=py39",
+        ],
+    ),
+    (
+        "Compile Python sources",
+        [sys.executable, "-m", "compileall", "-q", "src", "tests", "integration-tests"],
+    ),
+    (
+        "Run unit-tests",
+        [sys.executable, "-m", "unittest", "discover", "-s", "tests"],
+    ),
+    (
+        "Check fork drules compatibility",
+        [sys.executable, "integration-tests/check_fork_drules.py"],
+    ),
+)
+
+
+def require_ci_python_runtime():
+    try:
+        import lib2to3.refactor  # noqa: F401
+    except ModuleNotFoundError as e:
+        raise SystemExit(
+            "Full CI checks require Python with lib2to3 because the MAPS.ME "
+            "oracle is ported from Python 2 during integration tests. "
+            "Run this with Python 3.9, matching GitHub Actions."
+        ) from e
+
+
+def run_check(name, command):
+    print(f"\n==> {name}", flush=True)
+    print("+ " + " ".join(command), flush=True)
+    subprocess.run(command, cwd=REPO_ROOT, check=True)
+
+
+def main():
+    require_ci_python_runtime()
+    for name, command in CHECKS:
+        run_check(name, command)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mapcss/__init__.py
+++ b/src/mapcss/__init__.py
@@ -18,9 +18,106 @@
 import re
 import os
 import logging
+from functools import lru_cache
 from .StyleChooser import StyleChooser
 from .Condition import Condition
 from .Rule import type_matches
+
+
+log = logging.getLogger('mapcss.parser')
+condition_log = logging.getLogger('mapcss.parser.condition')
+
+
+def _skip_whitespace(value, index):
+    while index < len(value) and value[index].isspace():
+        index += 1
+    return index
+
+
+def _consume_name(value, index, allow_dash=False, allow_star=False):
+    start = index
+    while index < len(value):
+        char = value[index]
+        if char == '*' and allow_star:
+            index += 1
+        elif char == '-' and allow_dash:
+            index += 1
+        elif char == '_' or char.isalnum():
+            index += 1
+        else:
+            break
+    if index == start:
+        raise Exception("Unexpected construction: " + value)
+    return value[start:index], index
+
+
+def _consume_class_token(value):
+    index = 1
+    if index < len(value) and value[index] == ':':
+        index += 1
+    token, index = _consume_name(value, index, allow_dash=True, allow_star=True)
+    return value[:index], value[_skip_whitespace(value, index):]
+
+
+def _consume_zoom_token(value):
+    index = _skip_whitespace(value, 1)
+    if index >= len(value) or value[index].lower() != 'z':
+        raise Exception("Unexpected construction: " + value)
+    index += 1
+    start = index
+    while index < len(value) and (value[index].isdigit() or value[index] == '-'):
+        index += 1
+    if index == start:
+        raise Exception("Unexpected construction: " + value)
+    return value[start:index], value[_skip_whitespace(value, index):]
+
+
+def _consume_until(value, start, stop):
+    end = value.find(stop, start)
+    if end == -1:
+        raise Exception("Unexpected construction: " + value)
+    return value[start:end], value[_skip_whitespace(value, end + len(stop)):]
+
+
+def _consume_condition_token(value):
+    return _consume_until(value, 1, ']')
+
+
+def _consume_declaration_token(value):
+    return _consume_until(value, 1, '}')
+
+
+def _consume_comment_token(value):
+    return _consume_until(value, 2, '*/')[1]
+
+
+def _consume_import_token(value):
+    prefix = '@import("'
+    suffix = '");'
+    if not value.startswith(prefix):
+        return None
+    imported, rest = _consume_until(value, len(prefix), suffix)
+    return imported, rest
+
+
+def _consume_variable_token(value):
+    index = 1
+    if index >= len(value) or not value[index].isalpha():
+        raise Exception("Unexpected construction: " + value)
+    name, index = _consume_name(value, index)
+    index = _skip_whitespace(value, index)
+    if index >= len(value) or value[index] != ':':
+        raise Exception("Unexpected construction: " + value)
+    index = _skip_whitespace(value, index + 1)
+    raw, rest = _consume_until(value, index, ';')
+    return name, raw.strip(), rest
+
+
+def _consume_object_token(value):
+    if value[0] == '*':
+        return '*', value[_skip_whitespace(value, 1):]
+    obj, index = _consume_name(value, 0)
+    return obj, value[_skip_whitespace(value, index):]
 
 
 def _test_feature_compatibility(feature_type, selector_type):
@@ -112,17 +209,17 @@ class MapCSS():
         self.style_loaded = False
 
     def parseZoom(self, s):
-        if ZOOM_MINMAX.match(s):
-            return tuple([float(i) for i in ZOOM_MINMAX.match(s).groups()])
-        elif ZOOM_MIN.match(s):
-            return float(ZOOM_MIN.match(s).groups()[0]), self.maxscale
-        elif ZOOM_MAX.match(s):
-            return float(self.minscale), float(ZOOM_MAX.match(s).groups()[0])
-        elif ZOOM_SINGLE.match(s):
-            return float(ZOOM_SINGLE.match(s).groups()[0]), float(ZOOM_SINGLE.match(s).groups()[0])
-        else:
-            # TODO: Should we raise an exception here?
-            logging.error("unparsed zoom: %s" % s)
+        if '-' in s:
+            start, end = s.split('-', 1)
+            return (
+                float(start) if start else float(self.minscale),
+                float(end) if end else float(self.maxscale),
+            )
+        if s.isdigit():
+            zoom = float(s)
+            return zoom, zoom
+        # TODO: Should we raise an exception here?
+        logging.error("unparsed zoom: %s" % s)
 
     def build_choosers_tree(self, clname, type, cltag):
         if type not in self.choosers_by_type_zoom_tag:
@@ -260,7 +357,6 @@ class MapCSS():
         if not self.style_loaded:
             self.choosers = []
 
-        log = logging.getLogger('mapcss.parser')
         previous = oNONE  # what was the previous CSS word?
         sc = StyleChooser(self.scalepair)  # currently being assembled
 
@@ -272,14 +368,15 @@ class MapCSS():
 
                 wasBroken = False
                 while (css):
+                    marker = css[0]
+
                     # Class - :motorway, :builtup, :hover
-                    if CLASS.match(css):
+                    if marker == ':' or marker == '.':
                         if previous == oDECLARATION:
                             self.choosers.append(sc)
                             sc = StyleChooser(self.scalepair)
-                        cond = CLASS.match(css).groups()[0]
-                        log.debug("class found: %s" % (cond))
-                        css = CLASS.sub("", css, 1)
+                        cond, css = _consume_class_token(css)
+                        log.debug("class found: %s", cond)
                         sc.addCondition(Condition('eq', ("::class", cond)))
                         previous = oCONDITION
 
@@ -295,24 +392,23 @@ class MapCSS():
                         #previous = oCONDITION
 
                     # Zoom
-                    elif ZOOM.match(css):
+                    elif marker == '|':
                         if (previous != oOBJECT & previous != oCONDITION):
                             sc.newObject()
-                        cond = ZOOM.match(css).groups()[0]
-                        log.debug("zoom found: %s" % (cond))
-                        css = ZOOM.sub("", css, 1)
+                        cond, css = _consume_zoom_token(css)
+                        log.debug("zoom found: %s", cond)
                         sc.addZoom(self.parseZoom(cond))
                         previous = oZOOM
 
                     # Grouping - just a comma
-                    elif GROUP.match(css):
-                        css = GROUP.sub("", css, 1)
+                    elif marker == ',':
+                        css = css[_skip_whitespace(css, 1):]
                         sc.newGroup()
                         had_main_tag = False
                         previous = oGROUP
 
                     # Condition - [highway=primary] or [population>1000]
-                    elif CONDITION.match(css):
+                    elif marker == '[':
                         if (previous == oDECLARATION):
                             self.choosers.append(sc)
                             sc = StyleChooser(self.scalepair)
@@ -320,7 +416,7 @@ class MapCSS():
                         if (previous != oOBJECT) and (previous != oZOOM) and (previous != oCONDITION):
                             sc.newObject()
                             had_main_tag = False
-                        cond = CONDITION.match(css).groups()[0]
+                        cond, css = _consume_condition_token(css)
                         c = parseCondition(cond)
                         tag = c.extract_tag()
                         tag_type = static_tags.get(tag, None)
@@ -340,66 +436,62 @@ class MapCSS():
                             sc.addRuntimeCondition(c)
                         else:
                             raise Exception("Unknown tag '" + tag + "' in condition " + cond)
-                        css = CONDITION.sub("", css, 1)
                         previous = oCONDITION
 
                     # Object - way, node, relation
-                    elif OBJECT.match(css):
+                    elif marker == '*' or marker == '_' or marker.isalnum():
                         if (previous == oDECLARATION):
                             self.choosers.append(sc)
                             sc = StyleChooser(self.scalepair)
-                        obj = OBJECT.match(css).groups()[0]
-                        log.debug("object found: %s" % (obj))
-                        css = OBJECT.sub("", css, 1)
+                        obj, css = _consume_object_token(css)
+                        log.debug("object found: %s", obj)
                         sc.newObject(obj)
                         had_main_tag = False
                         previous = oOBJECT
 
                     # Declaration - {...}
-                    elif DECLARATION.match(css):
+                    elif marker == '{':
                         if previous == oDECLARATION or previous == oNONE:
                             raise Exception("Declaration without conditions")
-                        decl = DECLARATION.match(css).groups()[0]
-                        log.debug("declaration found: %s" % (decl))
+                        decl, css = _consume_declaration_token(css)
+                        log.debug("declaration found: %s", decl)
                         sc.addStyles(self.subst_variables(parseDeclaration(decl)))
-                        css = DECLARATION.sub("", css, 1)
                         previous = oDECLARATION
 
                     # CSS comment
-                    elif COMMENT.match(css):
+                    elif marker == '/':
+                        if not css.startswith('/*'):
+                            raise Exception("Unexpected construction: " + css)
                         log.debug("comment found")
-                        css = COMMENT.sub("", css, 1)
+                        css = _consume_comment_token(css)
 
                     # @import("filename.css");
-                    elif IMPORT.match(css):
-                        log.debug("import found")
-                        import_filename = os.path.join(basepath, IMPORT.match(css).groups()[0])
-                        try:
-                            css = IMPORT.sub("", css, 1)
-                            with open(import_filename, "r") as import_file:
-                                import_text = import_file.read()
-                            stck[-1][1] = css # store remained part
-                            stck.append([import_filename, import_text, import_text])
-                            wasBroken = True
-                            break
-                        except IOError as e:
-                            raise Exception("Cannot import file " + import_filename + "\n" + str(e))
+                    elif marker == '@':
+                        imported = _consume_import_token(css)
+                        if imported:
+                            import_filename_part, css = imported
+                            log.debug("import found")
+                            import_filename = os.path.join(basepath, import_filename_part)
+                            try:
+                                with open(import_filename, "r") as import_file:
+                                    import_text = import_file.read()
+                                stck[-1][1] = css # store remained part
+                                stck.append([import_filename, import_text, import_text])
+                                wasBroken = True
+                                break
+                            except IOError as e:
+                                raise Exception("Cannot import file " + import_filename + "\n" + str(e))
 
-                    # Variables
-                    elif VARIABLE_SET.match(css):
-                        name = VARIABLE_SET.match(css).groups()[0]
-                        log.debug("variable set found: %s" % name)
-                        self.variables[name] = VARIABLE_SET.match(css).groups()[1]
+                        name, raw_value, css = _consume_variable_token(css)
+                        log.debug("variable set found: %s", name)
+                        self.variables[name] = raw_value
                         self.unused_variables.add( name )
-                        css = VARIABLE_SET.sub("", css, 1)
                         previous = oVARIABLE_SET
 
-                    # Unknown pattern
-                    elif UNKNOWN.match(css):
-                        raise Exception("Unknown construction: " + UNKNOWN.match(css).group())
-
-                    # Must be unreachable
                     else:
+                        match = UNKNOWN.match(css)
+                        if match:
+                            raise Exception("Unknown construction: " + match.group())
                         raise Exception("Unexpected construction: " + css)
 
                     stck[-1][1] = css # store remained part
@@ -457,71 +549,99 @@ class MapCSS():
             print(f"Warning: Unused variables: {', '.join(self.unused_variables)}")
 
 # TODO: move to Condition.py
+@lru_cache(maxsize=4096)
+def _is_condition_key(value, allow_dash=False):
+    if not value:
+        return False
+    for char in value:
+        if char == '-' and allow_dash:
+            continue
+        if char not in (':', '_') and not char.isalnum():
+            return False
+    return True
+
+
+def _split_condition_operator(value, operator):
+    index = value.find(operator)
+    if index == -1:
+        return None
+    return value[:index].strip(), value[index + len(operator):].lstrip()
+
+
+@lru_cache(maxsize=4096)
 def parseCondition(s):
-    log = logging.getLogger('mapcss.parser.condition')
+    operator_value = s.lstrip()
+    value = operator_value.strip()
 
-    if CONDITION_TRUE.match(s):
-        a = CONDITION_TRUE.match(s).groups()
-        log.debug("condition true: %s" % (a[0]))
-        return Condition('true', a)
+    if value.endswith('?'):
+        key = value[:-1].strip()
+        if key.startswith('!'):
+            key = key[1:].strip()
+            if _is_condition_key(key):
+                condition_log.debug("condition invtrue: %s", key)
+                return Condition('ne', (key, "yes"))
+        elif _is_condition_key(key):
+            condition_log.debug("condition true: %s", key)
+            return Condition('true', (key,))
 
-    if CONDITION_invTRUE.match(s):
-        a = CONDITION_invTRUE.match(s).groups()
-        log.debug("condition invtrue: %s" % (a[0]))
-        return Condition('ne', (a[0], "yes"))
+    if '!=' in value:
+        key, right = _split_condition_operator(value, '!=')
+        if right and _is_condition_key(key):
+            condition_log.debug("condition NE: %s = %s", key, right)
+            return Condition('ne', (key, right))
 
-    if CONDITION_FALSE.match(s):
-        a = CONDITION_FALSE.match(s).groups()
-        log.debug("condition false: %s" % (a[0]))
-        return Condition('false', a)
+    if '=~/' in value:
+        key, right = _split_condition_operator(value, '=~/')
+        if right and _is_condition_key(key):
+            pattern = right.strip()
+            if pattern.endswith('/'):
+                right = pattern[:-1]
+                condition_log.debug("condition REGEX: %s = %s", key, right)
+                return Condition('regex', (key, right))
 
-    if CONDITION_SET.match(s):
-        a = CONDITION_SET.match(s).groups()
-        log.debug("condition set: %s" % (a))
-        return Condition('set', a)
+    for operator, condition_type, message_operator in (
+        ('<=', '<=', 'LE'),
+        ('>=', '>=', 'GE'),
+    ):
+        if operator in operator_value:
+            key, right = _split_condition_operator(operator_value, operator)
+            if right and _is_condition_key(key):
+                condition_log.debug("condition %s: %s = %s", message_operator, key, right)
+                return Condition(condition_type, (key, right))
+            raise Exception("condition UNKNOWN: " + s)
 
-    if CONDITION_UNSET.match(s):
-        a = CONDITION_UNSET.match(s).groups()
-        log.debug("condition unset: %s" % (a))
-        return Condition('unset', a)
+    if '=' in value:
+        key, right = _split_condition_operator(value, '=')
+        if not right or not _is_condition_key(key):
+            raise Exception("condition UNKNOWN: " + s)
+        if right.strip() == 'no' and _is_condition_key(key):
+            condition_log.debug("condition false: %s", key)
+            return Condition('false', (key,))
+        condition_log.debug("condition EQ: %s = %s", key, right)
+        return Condition('eq', (key, right))
 
-    if CONDITION_NE.match(s):
-        a = CONDITION_NE.match(s).groups()
-        log.debug("condition NE: %s = %s" % (a[0], a[1]))
-        return Condition('ne', a)
+    for operator, condition_type, message_operator in (
+        ('<', '<', 'LT'),
+        ('>', '>', 'GT'),
+    ):
+        if operator in operator_value:
+            key, right = _split_condition_operator(operator_value, operator)
+            if right and _is_condition_key(key):
+                condition_log.debug("condition %s: %s = %s", message_operator, key, right)
+                return Condition(condition_type, (key, right))
+            raise Exception("condition UNKNOWN: " + s)
 
-    if CONDITION_LE.match(s):
-        a = CONDITION_LE.match(s).groups()
-        log.debug("condition LE: %s <= %s" % (a[0], a[1]))
-        return Condition('<=', a)
+    if _is_condition_key(value, allow_dash=True):
+        condition_log.debug("condition set: %s", (value,))
+        return Condition('set', (value,))
 
-    if CONDITION_GE.match(s):
-        a = CONDITION_GE.match(s).groups()
-        log.debug("condition GE: %s >= %s" % (a[0], a[1]))
-        return Condition('>=', a)
+    if value.startswith('!'):
+        key = value[1:]
+        if _is_condition_key(key):
+            condition_log.debug("condition unset: %s", (key,))
+            return Condition('unset', (key,))
 
-    if CONDITION_LT.match(s):
-        a = CONDITION_LT.match(s).groups()
-        log.debug("condition LT: %s < %s" % (a[0], a[1]))
-        return Condition('<', a)
-
-    if CONDITION_GT.match(s):
-        a = CONDITION_GT.match(s).groups()
-        log.debug("condition GT: %s > %s" % (a[0], a[1]))
-        return Condition('>', a)
-
-    if CONDITION_REGEX.match(s):
-        a = CONDITION_REGEX.match(s).groups()
-        log.debug("condition REGEX: %s = %s" % (a[0], a[1]))
-        return Condition('regex', a)
-
-    if CONDITION_EQ.match(s):
-        a = CONDITION_EQ.match(s).groups()
-        log.debug("condition EQ: %s = %s" % (a[0], a[1]))
-        return Condition('eq', a)
-
-    else:
-        raise Exception("condition UNKNOWN: " + s)
+    raise Exception("condition UNKNOWN: " + s)
 
 
 def parseDeclaration(s):
@@ -530,11 +650,11 @@ def parseDeclaration(s):
     """
     t = {}
     for a in s.split(';'):
-        # if ((o=ASSIGNMENT_EVAL.exec(a)))   { t[o[1].replace(DASH,'_')]=new Eval(o[2]); }
-        if ASSIGNMENT.match(a):
-            tzz = ASSIGNMENT.match(a).groups()
-            t[tzz[0]] = tzz[1].strip().strip('"')
-            logging.debug("%s == %s" % (tzz[0], tzz[1]))
+        declaration = a.strip()
+        if ':' in declaration:
+            key, value = declaration.split(':', 1)
+            t[key.strip()] = value.strip().strip('"')
+            logging.debug("%s == %s" % (key, value))
         else:
             logging.debug("unknown %s" % (a))
     return [t] # TODO: don't wrap `t` dict into a list. Return `t` instead.

--- a/src/mapcss_benchmark_parse.py
+++ b/src/mapcss_benchmark_parse.py
@@ -1,0 +1,95 @@
+import argparse
+import time
+from pathlib import Path
+
+from .mapcss import MapCSS, COMMENT, CONDITION, IMPORT, parseCondition
+
+
+def read_stylesheet_tree(path, seen=None):
+    if seen is None:
+        seen = set()
+
+    path = path.resolve()
+    if path in seen:
+        return ""
+    seen.add(path)
+
+    source = path.read_text(encoding="utf-8")
+    imported_sources = []
+    for match in IMPORT.finditer(source):
+        imported_path = path.parent / match.group(1)
+        imported_sources.append(read_stylesheet_tree(imported_path, seen))
+
+    return "\n".join([source, *imported_sources])
+
+
+def infer_static_tags(source):
+    tags = {}
+    source = COMMENT.sub("", source)
+    for match in CONDITION.finditer(source):
+        tag = parseCondition(match.group(1)).extract_tag()
+        if tag != "*" and not tag.startswith("::"):
+            tags[tag] = True
+
+    return tags
+
+
+def parse_style(path, minzoom=0, maxzoom=30, static_tags=None):
+    source = path.read_text(encoding="utf-8")
+    parser = MapCSS(minzoom, maxzoom)
+    tags = static_tags if static_tags is not None else infer_static_tags(read_stylesheet_tree(path))
+
+    started_at = time.perf_counter()
+    parser.parse(source, filename=str(path), static_tags=tags)
+    elapsed = time.perf_counter() - started_at
+
+    return {
+        "path": str(path),
+        "bytes": len(source.encode("utf-8")),
+        "lines": source.count("\n") + (0 if source.endswith("\n") else 1),
+        "static_tags": len(tags),
+        "seconds": elapsed,
+        "choosers": len(parser.choosers),
+        "rule_chains": sum(len(chooser.ruleChains) for chooser in parser.choosers),
+    }
+
+
+def format_report(stats):
+    return "\n".join([
+        "MapCSS parse benchmark",
+        "path: %s" % stats["path"],
+        "bytes: %s" % stats["bytes"],
+        "lines: %s" % stats["lines"],
+        "static_tags: %s" % stats["static_tags"],
+        "seconds: %.6f" % stats["seconds"],
+        "choosers: %s" % stats["choosers"],
+        "rule_chains: %s" % stats["rule_chains"],
+    ])
+
+
+def build_arg_parser():
+    parser = argparse.ArgumentParser(
+        description="Measure MapCSS parser wall time for a stylesheet."
+    )
+    parser.add_argument("stylesheet", type=Path, help="Path to a MapCSS stylesheet.")
+    parser.add_argument("--minzoom", type=int, default=0)
+    parser.add_argument("--maxzoom", type=int, default=30)
+    parser.add_argument(
+        "--tag",
+        action="append",
+        dest="tags",
+        default=[],
+        help="Known static tag. Can be passed multiple times. Defaults to simple selector inference.",
+    )
+    return parser
+
+
+def main(argv=None):
+    args = build_arg_parser().parse_args(argv)
+    static_tags = {tag: True for tag in args.tags} if args.tags else None
+    stats = parse_style(args.stylesheet, args.minzoom, args.maxzoom, static_tags)
+    print(format_report(stats))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/testMapCSS.py
+++ b/tests/testMapCSS.py
@@ -41,6 +41,14 @@ class MapCSSTest(unittest.TestCase):
             "pattern-spacing": "@trunk0",
         })
 
+    def test_declarations_parse_colon_values_as_values(self):
+        decl = parseDeclaration(""" text:"addr:housename"; font-size: 9; """)
+
+        self.assertEqual(decl[0], {
+            "text": "addr:housename",
+            "font-size": "9",
+        })
+
     def test_parse_variables(self):
         parser = MapCSS()
         parser.parse("""
@@ -148,6 +156,57 @@ line|z7-9[highway=motorway],
 
         rule, object_id = parser.choosers[0].testChains({"highway": "trunk"})
         self.assertEqual(object_id, "::default")
+
+    def test_parse_scanner_handles_whitespace_comments_and_subparts(self):
+        parser = MapCSS()
+        parser.parse("""
+@road_color: #112233;
+/* A prose range like [12, 15] is not a condition. */
+way | z5-7 [ highway = primary ] ::casing,
+line|z8-[highway=secondary]::*
+{
+  color: @road_color;
+  width: 2;
+}
+""", static_tags={"highway": True})
+
+        self.assertEqual(len(parser.choosers), 1)
+        style_chooser = parser.choosers[0]
+        self.assertEqual(len(style_chooser.ruleChains), 2)
+        self.assertEqual(style_chooser.selzooms, [5, 19])
+
+        primary_rule, primary_object_id = style_chooser.testChains({"highway": "primary"})
+        self.assertEqual(primary_rule.subject, "way")
+        self.assertEqual(primary_rule.minZoom, 5)
+        self.assertEqual(primary_rule.maxZoom, 7)
+        self.assertEqual(primary_object_id, "::casing")
+
+        secondary_rule, secondary_object_id = style_chooser.testChains({"highway": "secondary"})
+        self.assertEqual(secondary_rule.subject, "line")
+        self.assertEqual(secondary_rule.minZoom, 8)
+        self.assertEqual(secondary_rule.maxZoom, 19)
+        self.assertEqual(secondary_object_id, "::*")
+
+        self.assertEqual(style_chooser.styles[0]["color"], (0.06666666666666667, 0.13333333333333333, 0.2))
+        self.assertEqual(style_chooser.styles[0]["width"], 2.0)
+
+    def test_parse_scanner_handles_wildcard_object_and_class(self):
+        parser = MapCSS()
+        parser.parse("""
+*|z3.railway::*
+{
+  opacity: 0.7;
+}
+""")
+
+        self.assertEqual(len(parser.choosers), 1)
+        style_chooser = parser.choosers[0]
+        self.assertEqual(style_chooser.selzooms, [3, 3])
+        self.assertEqual(style_chooser.ruleChains[0].subject, "")
+        self.assertEqual(
+            [condition.params for condition in style_chooser.ruleChains[0].conditions],
+            [("::class", ".railway"), ("::class", "::*")]
+        )
 
     def test_build_choosers_tree_matches_any_class_tag(self):
         parser = MapCSS(0, 10)

--- a/tests/testMapcssBenchmarkParse.py
+++ b/tests/testMapcssBenchmarkParse.py
@@ -1,0 +1,73 @@
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+# Add repository root to the import paths for package-style imports.
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from src import mapcss_benchmark_parse
+
+
+class MapcssBenchmarkParseTest(unittest.TestCase):
+    def test_parse_style_reports_basic_stats(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            stylesheet = Path(tmpdir) / "fixture.mapcss"
+            stylesheet.write_text(
+                "node[amenity=cafe] { icon-image: cafe; }\n"
+                "way[highway=primary] { width: 2; }\n",
+                encoding="utf-8",
+            )
+
+            stats = mapcss_benchmark_parse.parse_style(stylesheet)
+
+        self.assertEqual(stats["path"], str(stylesheet))
+        self.assertEqual(stats["lines"], 2)
+        self.assertGreater(stats["bytes"], 0)
+        self.assertEqual(stats["static_tags"], 2)
+        self.assertGreaterEqual(stats["seconds"], 0)
+        self.assertEqual(stats["choosers"], 2)
+        self.assertEqual(stats["rule_chains"], 2)
+
+    def test_infer_static_tags_from_conditions(self):
+        self.assertEqual(
+            mapcss_benchmark_parse.infer_static_tags("""
+                node[amenity=cafe] { icon-image: cafe; }
+                way[highway] { width: 2; }
+                /* CSS-ish prose can mention ranges like [12, 15]. */
+                *[name?] { text: name; }
+            """),
+            {"amenity": True, "highway": True, "name": True}
+        )
+
+    def test_parse_style_infers_tags_from_imports(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fixture_dir = Path(tmpdir)
+            stylesheet = fixture_dir / "main.mapcss"
+            stylesheet.write_text('@import("roads.mapcss");\n', encoding="utf-8")
+            (fixture_dir / "roads.mapcss").write_text(
+                "way[highway=primary] { width: 2; }\n",
+                encoding="utf-8",
+            )
+
+            stats = mapcss_benchmark_parse.parse_style(stylesheet)
+
+        self.assertEqual(stats["static_tags"], 1)
+        self.assertEqual(stats["choosers"], 1)
+
+    def test_format_report_is_copyable(self):
+        report = mapcss_benchmark_parse.format_report({
+            "path": "style.mapcss",
+            "bytes": 123,
+            "lines": 4,
+            "static_tags": 2,
+            "seconds": 0.125,
+            "choosers": 2,
+            "rule_chains": 3,
+        })
+
+        self.assertIn("MapCSS parse benchmark", report)
+        self.assertIn("path: style.mapcss", report)
+        self.assertIn("static_tags: 2", report)
+        self.assertIn("seconds: 0.125000", report)


### PR DESCRIPTION
### Summary

- add `python3 -m src.mapcss_benchmark_parse path/to/style.mapcss`
- report stylesheet size, line count, inferred static tag count, parse wall
  time, chooser count, and rule-chain count
- infer simple static tags from selectors by default so ad-hoc local styles can
  be measured without a separate tag list
- allow explicit `--tag` arguments for benchmark runs that need a fixed known
  tag set

This is a small measurement tool for #9. It does not claim to fix parser
performance by itself; it gives us a repeatable way to put numbers on the
current parser and future parser/cache work.

### Verification

```sh
python3 -m unittest tests.testMapcssBenchmarkParse
python3 -m unittest discover -s tests
python3 -m compileall -q src tests integration-tests
ruff check src tests integration-tests/*.py --exclude=src/drules_struct_pb2.py --target-version=py39
git diff --check
python3 -m src.mapcss_benchmark_parse tests/assets/case-1-import/main.mapcss
```

### Notes

The benchmark intentionally accepts an external stylesheet path. The historical
`osmosnimki-*` styles should not be re-bundled just to measure parse time.
