### PR TITLE
fix(mapcss): address benchmark review findings

### DIFF
--- a/src/mapcss/__init__.py
+++ b/src/mapcss/__init__.py
@@ -565,7 +565,7 @@ def _split_condition_operator(value, operator):
     index = value.find(operator)
     if index == -1:
         return None
-    return value[:index].strip(), value[index + len(operator):].lstrip()
+    return value[:index].strip(), value[index + len(operator):].strip()
 
 
 @lru_cache(maxsize=4096)
@@ -614,7 +614,7 @@ def parseCondition(s):
         key, right = _split_condition_operator(value, '=')
         if not right or not _is_condition_key(key):
             raise Exception("condition UNKNOWN: " + s)
-        if right.strip() == 'no' and _is_condition_key(key):
+        if right.strip().lower() == 'no' and _is_condition_key(key):
             condition_log.debug("condition false: %s", key)
             return Condition('false', (key,))
         condition_log.debug("condition EQ: %s = %s", key, right)

--- a/src/mapcss_benchmark_parse.py
+++ b/src/mapcss_benchmark_parse.py
@@ -5,22 +5,33 @@ from pathlib import Path
 from .mapcss import MapCSS, COMMENT, CONDITION, IMPORT, parseCondition
 
 
-def read_stylesheet_tree(path, seen=None):
+def read_stylesheet_sources(path, seen=None):
     if seen is None:
         seen = set()
 
     path = path.resolve()
     if path in seen:
-        return ""
+        return []
     seen.add(path)
 
     source = path.read_text(encoding="utf-8")
     imported_sources = []
-    for match in IMPORT.finditer(source):
+    uncommented_source = COMMENT.sub("", source)
+    for match in IMPORT.finditer(uncommented_source):
         imported_path = path.parent / match.group(1)
-        imported_sources.append(read_stylesheet_tree(imported_path, seen))
+        imported_sources.extend(read_stylesheet_sources(imported_path, seen))
 
-    return "\n".join([source, *imported_sources])
+    return [source, *imported_sources]
+
+
+def read_stylesheet_tree(path, seen=None):
+    return "".join(read_stylesheet_sources(path, seen))
+
+
+def count_source_lines(source):
+    if not source:
+        return 0
+    return source.count("\n") + (0 if source.endswith("\n") else 1)
 
 
 def infer_static_tags(source):
@@ -36,8 +47,10 @@ def infer_static_tags(source):
 
 def parse_style(path, minzoom=0, maxzoom=30, static_tags=None):
     source = path.read_text(encoding="utf-8")
+    source_tree_parts = read_stylesheet_sources(path)
+    source_tree = "".join(source_tree_parts)
     parser = MapCSS(minzoom, maxzoom)
-    tags = static_tags if static_tags is not None else infer_static_tags(read_stylesheet_tree(path))
+    tags = static_tags if static_tags is not None else infer_static_tags(source_tree)
 
     started_at = time.perf_counter()
     parser.parse(source, filename=str(path), static_tags=tags)
@@ -45,8 +58,8 @@ def parse_style(path, minzoom=0, maxzoom=30, static_tags=None):
 
     return {
         "path": str(path),
-        "bytes": len(source.encode("utf-8")),
-        "lines": source.count("\n") + (0 if source.endswith("\n") else 1),
+        "bytes": sum(len(part.encode("utf-8")) for part in source_tree_parts),
+        "lines": sum(count_source_lines(part) for part in source_tree_parts),
         "static_tags": len(tags),
         "seconds": elapsed,
         "choosers": len(parser.choosers),

--- a/tests/testCondition.py
+++ b/tests/testCondition.py
@@ -104,7 +104,7 @@ class ConditionTest(unittest.TestCase):
 
         cond:Condition = parseCondition("\tbbox_area > 4000000 ")
         self.assertEqual(cond.type, ">")
-        self.assertEqual(cond.params, ("bbox_area", "4000000 ")) # TODO fix parser to exclude trailing space
+        self.assertEqual(cond.params, ("bbox_area", "4000000"))
         self.assertTrue(cond.test({"bbox_area": "8000000"}))
         self.assertFalse(cond.test({"bbox_area": "4000000"}))
         self.assertFalse(cond.test({"highway": "secondary"}))
@@ -122,7 +122,7 @@ class ConditionTest(unittest.TestCase):
 
         cond:Condition = parseCondition("\tbbox_area < 4000000\n")
         self.assertEqual(cond.type, "<")
-        self.assertEqual(cond.params, ("bbox_area", "4000000\n")) # TODO fix parser to exclude trailing \n
+        self.assertEqual(cond.params, ("bbox_area", "4000000"))
         self.assertTrue(cond.test({"bbox_area": "100"}))
         self.assertTrue(cond.test({"bbox_area": "-1"}))
         self.assertTrue(cond.test({"bbox_area": "000"}))
@@ -145,7 +145,7 @@ class ConditionTest(unittest.TestCase):
 
         cond:Condition = parseCondition("\tbbox_area <= 4000000\n")
         self.assertEqual(cond.type, "<=")
-        self.assertEqual(cond.params, ("bbox_area", "4000000\n")) # TODO fix parser to exclude trailing \n
+        self.assertEqual(cond.params, ("bbox_area", "4000000"))
         self.assertTrue(cond.test({"bbox_area": "100"}))
         self.assertTrue(cond.test({"bbox_area": "-1"}))
         self.assertTrue(cond.test({"bbox_area": "000"}))
@@ -238,6 +238,17 @@ class ConditionTest(unittest.TestCase):
         #self.assertTrue(cond.test({"access": "no"}))      # test is not implemented for `false` condition
         #self.assertTrue(cond.test({"access": "private"})) # test is not implemented for `false` condition
         self.assertFalse(cond.test({"tunnel": "yes"}))
+
+        cond:Condition = parseCondition("access=No")
+        self.assertEqual(cond.type, "false")
+        self.assertEqual(cond.params, ("access", ))
+
+    def test_parser_strips_equality_value_whitespace(self):
+        cond:Condition = parseCondition(" amenity = car_wash \n")
+
+        self.assertEqual(cond.type, "eq")
+        self.assertEqual(cond.params, ("amenity", "car_wash"))
+        self.assertTrue(cond.test({"amenity": "car_wash"}))
 
     def test_parser_invTrue(self):
         """ Test conditions in format [!some_tag?] It works the same way as [some_tag != yes]

--- a/tests/testMapcssBenchmarkParse.py
+++ b/tests/testMapcssBenchmarkParse.py
@@ -55,6 +55,46 @@ class MapcssBenchmarkParseTest(unittest.TestCase):
 
         self.assertEqual(stats["static_tags"], 1)
         self.assertEqual(stats["choosers"], 1)
+        self.assertGreater(stats["bytes"], len('@import("roads.mapcss");\n'))
+        self.assertEqual(stats["lines"], 2)
+
+    def test_parse_style_counts_imported_files_without_join_separators(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fixture_dir = Path(tmpdir)
+            stylesheet = fixture_dir / "main.mapcss"
+            stylesheet.write_text('@import("roads.mapcss");', encoding="utf-8")
+            (fixture_dir / "roads.mapcss").write_text(
+                "way[highway=primary] { width: 2; }",
+                encoding="utf-8",
+            )
+
+            stats = mapcss_benchmark_parse.parse_style(stylesheet)
+
+        self.assertEqual(stats["static_tags"], 1)
+        self.assertEqual(stats["bytes"], (
+            len('@import("roads.mapcss");'.encode("utf-8"))
+            + len("way[highway=primary] { width: 2; }".encode("utf-8"))
+        ))
+        self.assertEqual(stats["lines"], 2)
+
+    def test_parse_style_ignores_commented_imports(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fixture_dir = Path(tmpdir)
+            stylesheet = fixture_dir / "main.mapcss"
+            stylesheet.write_text(
+                '/* @import("missing.mapcss"); */\n'
+                "node[amenity=cafe] { icon-image: cafe; }\n",
+                encoding="utf-8",
+            )
+
+            stats = mapcss_benchmark_parse.parse_style(
+                stylesheet,
+                static_tags={"amenity": True},
+            )
+
+        self.assertEqual(stats["static_tags"], 1)
+        self.assertEqual(stats["choosers"], 1)
+        self.assertEqual(stats["lines"], 2)
 
     def test_format_report_is_copyable(self):
         report = mapcss_benchmark_parse.format_report({


### PR DESCRIPTION
Follow-up to #66.\n\n- Treat MapCSS condition RHS whitespace consistently and keep =No as boolean false.\n- Count imported MapCSS files in parse benchmark bytes/lines.\n- Add regression coverage for both review findings.\n\nValidation:\n- python3 -m pytest tests/testCondition.py tests/testMapcssBenchmarkParse.py tests/testCheckForkDrules.py -q\n- python3 -m unittest discover -s tests\n- MAPS.ME drules oracle rerun on preserved workspace after oracle normalization: clear/dark/vehicle clear/vehicle dark matched.\n\nNote: a full fresh fork-oracle rerun hit transient network failures while checking out the pinned mapsme/omim sparse tree.